### PR TITLE
Derive string representations for `RawRepresentable` structs using `swift-derive`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-12']
-        swift: ['5.7']
+        swift: ['5.9']
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: swift-actions/setup-swift@v1
       with:
-        swift-version: '5.7'
+        swift-version: '5.9'
     - name: Generate Docs
       uses: fwcd/swift-docc-action@v1
       with:

--- a/Package.resolved
+++ b/Package.resolved
@@ -37,6 +37,15 @@
       }
     },
     {
+      "identity" : "swift-derive",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/fwcd/swift-derive.git",
+      "state" : {
+        "revision" : "76d63cae7b8c57cbe2154d5b00c1f824a43cd0c0",
+        "version" : "0.1.3"
+      }
+    },
+    {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
@@ -88,6 +97,15 @@
       "state" : {
         "revision" : "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
         "version" : "1.19.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
+        "version" : "509.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/websocket-kit.git", .upToNextMinor(from: "2.14.0")),
         .package(url: "https://github.com/Kitura/BlueSocket.git", .upToNextMinor(from: "2.0.4")),
+        .package(url: "https://github.com/fwcd/swift-derive.git", from: "0.1.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.2.1"),
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
@@ -37,6 +38,7 @@ let package = Package(
         .target(name: "Discord", dependencies: [
             .product(name: "WebSocketKit", package: "websocket-kit"),
             .product(name: "Socket", package: "BlueSocket"),
+            .product(name: "Derive", package: "swift-derive"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "BigInt", package: "BigInt"),
         ]),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 
 // The MIT License (MIT)
 // Copyright (c) 2016 Erik Little

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Check out the [docs](https://fwcd.github.io/swift-discord/documentation/discord)
 
 ## Requirements
 
-- Swift 5.7+
+- Swift 5.9+
 
 ## Building
 

--- a/Sources/Discord/Application/DiscordApplication.swift
+++ b/Sources/Discord/Application/DiscordApplication.swift
@@ -16,6 +16,7 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+import Derive
 import Foundation
 
 /// An application using the Discord API.
@@ -93,6 +94,7 @@ public struct DiscordApplication: Codable, Hashable {
 }
 
 /// Public flags of an application.
+@DeriveCustomStringConvertible
 public struct DiscordApplicationFlags: RawRepresentable, Codable, OptionSet, Hashable {
     public var rawValue: UInt32
 

--- a/Sources/Discord/Audit/DiscordAuditLogEntry.swift
+++ b/Sources/Discord/Audit/DiscordAuditLogEntry.swift
@@ -15,6 +15,7 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+import Derive
 import Foundation
 
 /// Represents an audit entry.
@@ -121,7 +122,8 @@ public struct DiscordAuditLogChange: Decodable {
 }
 
 /// The types of audit actions.
-public struct DiscordAuditLogActionType: RawRepresentable, Codable {
+@DeriveCustomStringConvertible
+public struct DiscordAuditLogActionType: RawRepresentable, Codable, Hashable {
     public var rawValue: Int
 
     public static let guildUpdate = DiscordAuditLogActionType(rawValue: 1)

--- a/Sources/Discord/Channel/DiscordChannel.swift
+++ b/Sources/Discord/Channel/DiscordChannel.swift
@@ -16,6 +16,7 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+import Derive
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -153,6 +154,7 @@ public struct DiscordChannel: Codable, Identifiable, Hashable {
 }
 
 /// Represents the type of a channel.
+@DeriveCustomStringConvertible
 public struct DiscordChannelType: RawRepresentable, Codable, Hashable {
     public var rawValue: Int
 

--- a/Sources/Discord/Channel/DiscordMessage.swift
+++ b/Sources/Discord/Channel/DiscordMessage.swift
@@ -16,6 +16,7 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+import Derive
 import Foundation
 
 /// Represents a Discord chat message.
@@ -279,6 +280,7 @@ public struct DiscordMessage: ExpressibleByStringLiteral, Identifiable, Codable,
     /// Represents an action that be taken on a message.
     public struct Activity: Codable, Hashable {
         /// Represents the type of activity.
+        @DeriveCustomStringConvertible
         public struct ActivityType: RawRepresentable, Codable, Hashable {
             public var rawValue: Int
 
@@ -307,6 +309,7 @@ public struct DiscordMessage: ExpressibleByStringLiteral, Identifiable, Codable,
 }
 
 /// The type of a message.
+@DeriveCustomStringConvertible
 public struct DiscordMessageType: RawRepresentable, Codable, Hashable {
     public var rawValue: Int
 

--- a/Sources/Discord/Channel/DiscordMessageComponent.swift
+++ b/Sources/Discord/Channel/DiscordMessageComponent.swift
@@ -15,6 +15,7 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+import Derive
 import Foundation
 
 /// An interactive part of a message.
@@ -117,6 +118,7 @@ public struct DiscordMessageComponent: Codable, Hashable {
     }
 }
 
+@DeriveCustomStringConvertible
 public struct DiscordMessageComponentType: RawRepresentable, Hashable, Codable {
     public var rawValue: Int
 
@@ -143,6 +145,7 @@ public struct DiscordMessageComponentEmoji: Codable, Identifiable, Hashable {
 }
 
 /// A visual button component style.
+@DeriveCustomStringConvertible
 public struct DiscordMessageComponentButtonStyle: RawRepresentable, Hashable, Codable {
     public var rawValue: Int
 

--- a/Sources/Discord/Gateway/DiscordGatewayCloseReason.swift
+++ b/Sources/Discord/Gateway/DiscordGatewayCloseReason.swift
@@ -16,10 +16,12 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+import Derive
 import Foundation
 
 /// Represents the reason a gateway was closed.
-public struct DiscordGatewayCloseReason: RawRepresentable, Codable {
+@DeriveCustomStringConvertible
+public struct DiscordGatewayCloseReason: RawRepresentable, Codable, Hashable {
     public var rawValue: Int
 
     /// We don't quite know why the gateway closed.

--- a/Sources/Discord/Gateway/DiscordGatewayIntents.swift
+++ b/Sources/Discord/Gateway/DiscordGatewayIntents.swift
@@ -1,7 +1,10 @@
+import Derive
+
 /// An intent defines the events the gateway should
 /// subscribe to.
 ///
 /// See https://discord.com/developers/docs/topics/gateway#gateway-intents
+@DeriveCustomStringConvertible
 public struct DiscordGatewayIntents: OptionSet, RawRepresentable, Codable, Hashable {
     public let rawValue: Int
 

--- a/Sources/Discord/Gateway/Dispatch/DiscordDispatchEventType.swift
+++ b/Sources/Discord/Gateway/Dispatch/DiscordDispatchEventType.swift
@@ -1,4 +1,7 @@
+import Derive
+
 /// An enum that represents the dispatch events Discord sends.
+@DeriveCustomStringConvertible
 public struct DiscordDispatchEventType: RawRepresentable, Codable, Hashable {
     public let rawValue: String
 

--- a/Sources/Discord/Gateway/Payload/DiscordGatewayOpcode.swift
+++ b/Sources/Discord/Gateway/Payload/DiscordGatewayOpcode.swift
@@ -16,7 +16,10 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+import Derive
+
 /// Represents a regular gateway opcode.
+@DeriveCustomStringConvertible
 public struct DiscordGatewayOpcode: RawRepresentable, Codable, Hashable {
     public var rawValue: Int
 

--- a/Sources/Discord/Interaction/DiscordApplicationCommand.swift
+++ b/Sources/Discord/Interaction/DiscordApplicationCommand.swift
@@ -1,3 +1,4 @@
+import Derive
 import Foundation
 
 /// Represents a slash-command. The base command model of the
@@ -124,6 +125,7 @@ public enum DiscordApplicationCommandOptionChoiceValue: Codable, Hashable {
     }
 }
 
+@DeriveCustomStringConvertible
 public struct DiscordApplicationCommandOptionType: RawRepresentable, Codable, Hashable {
     public var rawValue: Int
 

--- a/Sources/Discord/Interaction/DiscordInteraction.swift
+++ b/Sources/Discord/Interaction/DiscordInteraction.swift
@@ -1,3 +1,4 @@
+import Derive
 import Foundation
 
 /// Represents a slash-command invocation by the user.
@@ -47,6 +48,7 @@ public struct DiscordInteraction: Identifiable, Codable, Hashable {
     public let version: Int
 }
 
+@DeriveCustomStringConvertible
 public struct DiscordInteractionType: RawRepresentable, Hashable, Codable {
     public var rawValue: Int
 

--- a/Sources/Discord/Sticker/DiscordSticker.swift
+++ b/Sources/Discord/Sticker/DiscordSticker.swift
@@ -15,6 +15,8 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+import Derive
+
 public struct DiscordSticker: Identifiable, Codable, Hashable {
     public enum CodingKeys: String, CodingKey {
         case id
@@ -45,6 +47,7 @@ public struct DiscordSticker: Identifiable, Codable, Hashable {
     public let formatType: DiscordStickerFormatType?
 }
 
+@DeriveCustomStringConvertible
 public struct DiscordStickerFormatType: RawRepresentable, Codable, Hashable {
     public var rawValue: Int
 

--- a/Sources/Discord/User/DiscordPermissions.swift
+++ b/Sources/Discord/User/DiscordPermissions.swift
@@ -17,8 +17,10 @@
 // DEALINGS IN THE SOFTWARE.
 
 import BigInt
+import Derive
 
 /// Represents a Discord Permission. Calculating Permissions involves bitwise operations.
+@DeriveCustomStringConvertible
 public struct DiscordPermissions: RawRepresentable, OptionSet, Codable, Hashable {
     public var rawValue: BigInt
 
@@ -161,6 +163,7 @@ public enum DiscordPermissionsError: Error {
 }
 
 /// Represents a permission overwrite type for a channel.
+@DeriveCustomStringConvertible
 public struct DiscordPermissionOverwriteType: RawRepresentable, Codable, Hashable {
     public var rawValue: Int
 

--- a/Sources/Discord/User/DiscordPresence.swift
+++ b/Sources/Discord/User/DiscordPresence.swift
@@ -16,6 +16,7 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+import Derive
 import Foundation
 
 /// Represents a presence.
@@ -62,6 +63,7 @@ public struct DiscordPresence: Codable, Identifiable, Hashable {
 }
 
 /// Represents a presence status.
+@DeriveCustomStringConvertible
 public struct DiscordPresenceStatus: RawRepresentable, Codable, Hashable {
     public var rawValue: String
 
@@ -80,6 +82,7 @@ public struct DiscordPresenceStatus: RawRepresentable, Codable, Hashable {
 }
 
 /// Represents an activity type.
+@DeriveCustomStringConvertible
 public struct DiscordActivityType: RawRepresentable, Codable, Hashable {
     public var rawValue: Int
 


### PR DESCRIPTION
This uses the new Swift 5.9 macros to provide a better string representation for structs conforming to `RawRepresentable` (i.e. 'open' enums). Marked as a draft for now since the tests unfortunately fail with a linker error that we'll have to investigate.