### PR TITLE
Migrate to v10 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ class PingPongBot: DiscordClientDelegate {
     private var client: DiscordClient!
 
     init() {
-        client = DiscordClient(token: "Bot <your token>", delegate: self)
+        client = DiscordClient(
+            token: "Bot <your token>",
+            delegate: self,
+            configuration: [.intents([.guildMessages, .messageContent])]
+        )
         client.connect()
     }
 

--- a/Snippets/PingPongBot.swift
+++ b/Snippets/PingPongBot.swift
@@ -6,7 +6,11 @@ class PingPongBot: DiscordClientDelegate {
     private var client: DiscordClient!
 
     init(token: String) {
-        client = DiscordClient(token: "Bot \(token)", delegate: self)
+        client = DiscordClient(
+            token: "Bot \(token)",
+            delegate: self,
+            configuration: [.intents([.guildMessages, .messageContent])]
+        )
         client.connect()
     }
 

--- a/Sources/Discord/Channel/DiscordMessage.swift
+++ b/Sources/Discord/Channel/DiscordMessage.swift
@@ -25,7 +25,7 @@ public struct DiscordMessage: ExpressibleByStringLiteral, Identifiable, Codable,
         enum CodingKeys: String, CodingKey {
             case content
             case tts
-            case embed
+            case embeds
             case allowedMentions = "allowed_mentions"
             case messageReference = "message_reference"
             case components
@@ -33,7 +33,7 @@ public struct DiscordMessage: ExpressibleByStringLiteral, Identifiable, Codable,
 
         let content: String
         let tts: Bool
-        let embed: DiscordEmbed?
+        let embeds: [DiscordEmbed]
         let allowedMentions: DiscordAllowedMentions?
         let messageReference: DiscordMessageReference?
         let components: [DiscordMessageComponent]?
@@ -43,21 +43,21 @@ public struct DiscordMessage: ExpressibleByStringLiteral, Identifiable, Codable,
     public struct Edit: Codable, Hashable {
         enum CodingKeys: String, CodingKey {
             case content
-            case embed
+            case embeds
             case components
         }
 
         public var content: String?
-        public var embed: DiscordEmbed?
+        public var embeds: [DiscordEmbed]?
         public var components: [DiscordMessageComponent]?
 
         public init(
             content: String? = nil,
-            embed: DiscordEmbed? = nil,
+            embeds: [DiscordEmbed]? = nil,
             components: [DiscordMessageComponent]? = nil
         ) {
             self.content = content
-            self.embed = embed
+            self.embeds = embeds
             self.components = components
         }
     }
@@ -241,7 +241,7 @@ public struct DiscordMessage: ExpressibleByStringLiteral, Identifiable, Codable,
     ///
     public init(
         content: String = "",
-        embed: DiscordEmbed? = nil,
+        embeds: [DiscordEmbed] = [],
         files: [DiscordFileUpload] = [],
         tts: Bool = false,
         allowedMentions: DiscordAllowedMentions? = nil,
@@ -249,7 +249,7 @@ public struct DiscordMessage: ExpressibleByStringLiteral, Identifiable, Codable,
         components: [DiscordMessageComponent] = []
     ) {
         self.content = content
-        self.embeds = embed.map { [$0] } ?? []
+        self.embeds = embeds
         self.activity = nil
         self.application = nil
         self.files = files
@@ -284,7 +284,7 @@ public struct DiscordMessage: ExpressibleByStringLiteral, Identifiable, Codable,
         let fields = Draft(
             content: content ?? "",
             tts: tts ?? false,
-            embed: embeds?.first,
+            embeds: embeds ?? [],
             allowedMentions: allowedMentions,
             messageReference: messageReference,
             components: components

--- a/Sources/Discord/DiscordAPIVersion.swift
+++ b/Sources/Discord/DiscordAPIVersion.swift
@@ -1,2 +1,2 @@
 /// The Discord API version to use.
-let discordAPIVersion = 9
+let discordAPIVersion = 10

--- a/Sources/Discord/Documentation.docc/Documentation.md
+++ b/Sources/Discord/Documentation.docc/Documentation.md
@@ -16,7 +16,11 @@ class Bot: DiscordClientDelegate {
     private var client: DiscordClient!
 
     init() {
-        client = DiscordClient(token: "Bot myjwt.from.discord", delegate: self)
+        client = DiscordClient(
+            token: "Bot <your token>",
+            delegate: self,
+            configuration: [.intents([.guildMessages, .messageContent])]
+        )
         client.connect()
     }
 

--- a/Sources/Discord/Gateway/DiscordGatewayIntents.swift
+++ b/Sources/Discord/Gateway/DiscordGatewayIntents.swift
@@ -35,11 +35,14 @@ public struct DiscordGatewayIntents: OptionSet, RawRepresentable, Codable, Hasha
     public static let directMessageReactions = DiscordGatewayIntents(rawValue: 1 << 13)
     /// Direct message typing indicators.
     public static let directMessageTyping = DiscordGatewayIntents(rawValue: 1 << 14)
+    /// (Non-empty) message content in message data across the API. This is a privileged intent.
+    public static let messageContent = DiscordGatewayIntents(rawValue: 1 << 15)
 
     /// The privileged intents (which may require enabling in the Discord developer console).
     public static let privilegedIntents: DiscordGatewayIntents = [
         .guildMembers,
-        .guildPresences
+        .guildPresences,
+        .messageContent,
     ]
 
     /// The unprivileged intents. Use these if you don't need the privileged intents.

--- a/Sources/Discord/Rest/DiscordEndpointConsumer.swift
+++ b/Sources/Discord/Rest/DiscordEndpointConsumer.swift
@@ -251,14 +251,14 @@ public protocol DiscordEndpointConsumer {
     /// Sending a message with an embed:
     ///
     /// ```swift
-    /// client.sendMessage(DiscordMessage(content: "This message also comes with an embed", embed: embed),
+    /// client.sendMessage(DiscordMessage(content: "This message also comes with an embed", embeds: [embed]),
     ///                    to: channelId, callback: nil)
     /// ```
     ///
     /// Sending a fully loaded message:
     ///
     /// ```swift
-    /// client.sendMessage(DiscordMessage(content: "This message has it all", embed: embed, file: file),
+    /// client.sendMessage(DiscordMessage(content: "This message has it all", embeds: [embed], file: file),
     ///                    to: channelId, callback: nil)
     /// ```
     ///


### PR DESCRIPTION
### Fixes #18 

The major change is that we need the messageContent intent for anything involving the content, embeds etc, which includes our ping-pong example.

In the longer run, we'd definitely want to improve the docs around slash commands, especially with with some examples, but that's out-of-scope here and is tracked in #19.

Additionally, we'd have to support multiple embeds, see https://discord.com/developers/docs/change-log#api-v10.