### PR TITLE
Re-add voice support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "bluesocket",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kitura/BlueSocket.git",
+      "state" : {
+        "revision" : "7b23a867008e0027bfd6f4d398d44720707bc8ca",
+        "version" : "2.0.4"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",

--- a/Package.swift
+++ b/Package.swift
@@ -28,15 +28,21 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/websocket-kit.git", .upToNextMinor(from: "2.14.0")),
+        .package(url: "https://github.com/Kitura/BlueSocket.git", .upToNextMinor(from: "2.0.4")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.2.1"),
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
     ],
     targets: [
+        .systemLibrary(name: "COpus", pkgConfig: "opus"),
+        .systemLibrary(name: "CSodium", pkgConfig: "libsodium"),
         .target(name: "Discord", dependencies: [
             .product(name: "WebSocketKit", package: "websocket-kit"),
+            .product(name: "Socket", package: "BlueSocket"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "BigInt", package: "BigInt"),
+            .target(name: "COpus"),
+            .target(name: "CSodium"),
         ]),
         .testTarget(name: "DiscordTests", dependencies: [
             .target(name: "Discord"),

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Check out the [docs](https://fwcd.github.io/swift-discord/documentation/discord)
 - macOS and Linux support
 - v9 API (including threads, interactions, slash commands and message components)
 - Configurable sharding
+- Voice support
 
 ## Requirements
 

--- a/Sources/COpus/ctl_shim.h
+++ b/Sources/COpus/ctl_shim.h
@@ -1,0 +1,65 @@
+// Define macros for OPUS_SHIM_GENERIC_CTL0, OPUS_SHIM_GENERIC_CTL1, OPUS_SHIM_ENCODER_CTL1, and OPUS_SHIM_DECODER_CTL1 and then include this file
+// GENERIC are for both decoders and encoders, ENCODER is for encoders only, DECODER is for decoders only.  0/1 is the number of arguments
+// Arguments are name of opus macro minus the OPUS_ prefix, the same name lowercased, the type of the argument, and the argument variable name
+
+#ifndef OPUS_SHIM_GENERIC_CTL0
+#  error "Must define OPUS_SHIM_GENERIC_CTL0(macroname, funcname) before including this file."
+#endif
+
+#ifndef OPUS_SHIM_GENERIC_CTL1
+#  error "Must define OPUS_SHIM_GENERIC_CTL1(macroname, funcname, vartype, varname) before including this file."
+#endif
+
+#ifndef OPUS_SHIM_ENCODER_CTL1
+#  error "Must define OPUS_SHIM_ENCODER_CTL1(macroname, funcname, vartype, varname) before including this file."
+#endif
+
+#ifndef OPUS_SHIM_DECODER_CTL1
+#  error "Must define OPUS_SHIM_DECODER_CTL1(macroname, funcname, vartype, varname) before including this file."
+#endif
+
+OPUS_SHIM_GENERIC_CTL0(RESET_STATE, reset_state)
+OPUS_SHIM_GENERIC_CTL1(GET_FINAL_RANGE, get_final_range, opus_uint32*, range)
+OPUS_SHIM_GENERIC_CTL1(GET_BANDWIDTH, get_bandwidth, opus_int32*, bandwidth)
+OPUS_SHIM_GENERIC_CTL1(GET_SAMPLE_RATE, get_sample_rate, opus_int32*, sampleRate)
+OPUS_SHIM_GENERIC_CTL1(SET_PHASE_INVERSION_DISABLED, set_phase_inversion_disabled, opus_int32, phaseInversionDisabled)
+OPUS_SHIM_GENERIC_CTL1(GET_PHASE_INVERSION_DISABLED, get_phase_inversion_disabled, opus_int32*, phaseInversionDisabled)
+OPUS_SHIM_ENCODER_CTL1(SET_COMPLEXITY, set_complexity, opus_int32, complexity)
+OPUS_SHIM_ENCODER_CTL1(GET_COMPLEXITY, get_complexity, opus_int32*, complexity)
+OPUS_SHIM_ENCODER_CTL1(SET_BITRATE, set_bitrate, opus_int32, bitrate)
+OPUS_SHIM_ENCODER_CTL1(GET_BITRATE, get_bitrate, opus_int32*, bitrate)
+OPUS_SHIM_ENCODER_CTL1(SET_VBR, set_vbr, opus_int32, vbr)
+OPUS_SHIM_ENCODER_CTL1(GET_VBR, get_vbr, opus_int32*, vbr)
+OPUS_SHIM_ENCODER_CTL1(SET_VBR_CONSTRAINT, set_vbr_constraint, opus_int32, constraint)
+OPUS_SHIM_ENCODER_CTL1(GET_VBR_CONSTRAINT, get_vbr_constraint, opus_int32*, constraint)
+OPUS_SHIM_ENCODER_CTL1(SET_FORCE_CHANNELS, set_force_channels, opus_int32, channels)
+OPUS_SHIM_ENCODER_CTL1(GET_FORCE_CHANNELS, get_force_channels, opus_int32*, channels)
+OPUS_SHIM_ENCODER_CTL1(SET_MAX_BANDWIDTH, set_max_bandwidth, opus_int32, bandwidth)
+OPUS_SHIM_ENCODER_CTL1(GET_MAX_BANDWIDTH, get_max_bandwidth, opus_int32*, bandwidth)
+OPUS_SHIM_ENCODER_CTL1(SET_BANDWIDTH, set_bandwidth, opus_int32*, bandwidth)
+OPUS_SHIM_ENCODER_CTL1(SET_SIGNAL, set_signal, opus_int32, signal)
+OPUS_SHIM_ENCODER_CTL1(GET_SIGNAL, get_signal, opus_int32*, signal)
+OPUS_SHIM_ENCODER_CTL1(SET_APPLICATION, set_application, opus_int32, application)
+OPUS_SHIM_ENCODER_CTL1(GET_APPLICATION, get_application, opus_int32*, application)
+OPUS_SHIM_ENCODER_CTL1(GET_LOOKAHEAD, get_lookahead, opus_int32*, lookahead)
+OPUS_SHIM_ENCODER_CTL1(SET_INBAND_FEC, set_inband_fec, opus_int32, fec)
+OPUS_SHIM_ENCODER_CTL1(GET_INBAND_FEC, get_inband_fec, opus_int32*, fec)
+OPUS_SHIM_ENCODER_CTL1(SET_PACKET_LOSS_PERC, set_packet_loss_perc, opus_int32, loss)
+OPUS_SHIM_ENCODER_CTL1(GET_PACKET_LOSS_PERC, get_packet_loss_perc, opus_int32*, loss)
+OPUS_SHIM_ENCODER_CTL1(SET_DTX, set_dtx, opus_int32, dtx)
+OPUS_SHIM_ENCODER_CTL1(GET_DTX, get_dtx, opus_int32*, dtx)
+OPUS_SHIM_ENCODER_CTL1(SET_LSB_DEPTH, set_lsb_depth, opus_int32, depth)
+OPUS_SHIM_ENCODER_CTL1(GET_LSB_DEPTH, get_lsb_depth, opus_int32*, depth)
+OPUS_SHIM_ENCODER_CTL1(SET_EXPERT_FRAME_DURATION, set_expert_frame_duration, opus_int32, duration)
+OPUS_SHIM_ENCODER_CTL1(GET_EXPERT_FRAME_DURATION, get_expert_frame_duration, opus_int32*, duration)
+OPUS_SHIM_ENCODER_CTL1(SET_PREDICTION_DISABLED, set_prediction_disabled, opus_int32, predictionDisabled)
+OPUS_SHIM_ENCODER_CTL1(GET_PREDICTION_DISABLED, get_prediction_disabled, opus_int32*, predictionDisabled)
+OPUS_SHIM_DECODER_CTL1(SET_GAIN, set_gain, opus_int32, gain)
+OPUS_SHIM_DECODER_CTL1(GET_GAIN, get_gain, opus_int32*, gain)
+OPUS_SHIM_DECODER_CTL1(GET_LAST_PACKET_DURATION, get_last_packet_duration, opus_int32*, duration)
+OPUS_SHIM_DECODER_CTL1(GET_PITCH, get_pitch, opus_int32*, pitch)
+
+#undef OPUS_SHIM_GENERIC_CTL0
+#undef OPUS_SHIM_GENERIC_CTL1
+#undef OPUS_SHIM_ENCODER_CTL1
+#undef OPUS_SHIM_DECODER_CTL1

--- a/Sources/COpus/module.modulemap
+++ b/Sources/COpus/module.modulemap
@@ -1,0 +1,5 @@
+module COpus [system] {
+  header "shim.h"
+  link "opus"
+  export *
+}

--- a/Sources/COpus/shim.h
+++ b/Sources/COpus/shim.h
@@ -1,0 +1,38 @@
+#ifndef __COPUS_SHIM_H__
+#define __COPUS_SHIM_H__
+
+#include <opus.h>
+
+#define OPUS_SHIM_GENERIC_CTL0(macroname, funcname) \
+static inline int opus_encoder_##funcname(OpusEncoder *st) {\
+	return opus_encoder_ctl(st, OPUS_##macroname);\
+}
+
+#define OPUS_SHIM_GENERIC_CTL1(macroname, funcname, vartype, varname) \
+static inline int opus_encoder_##funcname(OpusEncoder *st, vartype varname) {\
+	return opus_encoder_ctl(st, OPUS_##macroname(varname));\
+}
+
+#define OPUS_SHIM_ENCODER_CTL1(macroname, funcname, vartype, varname) OPUS_SHIM_GENERIC_CTL1(macroname, funcname, vartype, varname)
+
+#define OPUS_SHIM_DECODER_CTL1(macroname, funcname, vartype, varname)
+
+#include "ctl_shim.h"
+
+#define OPUS_SHIM_GENERIC_CTL0(macroname, funcname) \
+static inline int opus_decoder_##funcname(OpusDecoder *st) {\
+	return opus_decoder_ctl(st, OPUS_##macroname);\
+}
+
+#define OPUS_SHIM_GENERIC_CTL1(macroname, funcname, vartype, varname) \
+static inline int opus_decoder_##funcname(OpusDecoder *st, vartype varname) {\
+	return opus_decoder_ctl(st, OPUS_##macroname(varname));\
+}
+
+#define OPUS_SHIM_ENCODER_CTL1(macroname, funcname, vartype, varname)
+
+#define OPUS_SHIM_DECODER_CTL1(macroname, funcname, vartype, varname) OPUS_SHIM_GENERIC_CTL1(macroname, funcname, vartype, varname)
+
+#include "ctl_shim.h"
+
+#endif

--- a/Sources/CSodium/module.modulemap
+++ b/Sources/CSodium/module.modulemap
@@ -1,0 +1,5 @@
+module CSodium [system] {
+  header "shim.h"
+  link "sodium"
+  export *
+}

--- a/Sources/CSodium/shim.h
+++ b/Sources/CSodium/shim.h
@@ -1,0 +1,6 @@
+#ifndef __SODIUM_SHIM_H__
+#define __SODIUM_SHIM_H__
+
+#include <sodium.h>
+
+#endif

--- a/Sources/Discord/DiscordClient.swift
+++ b/Sources/Discord/DiscordClient.swift
@@ -98,7 +98,12 @@ public class DiscordClient: DiscordShardManagerDelegate, DiscordUserActor, Disco
     /// The DiscordUser this client is connected to.
     public private(set) var user: DiscordUser?
 
+    /// A manager for the voice engines.
+    public private(set) var voiceManager: DiscordVoiceManager!
+
     var channelCache = DiscordIDDictionary<DiscordChannel>()
+
+    private let voiceQueue = DispatchQueue(label: "voiceQueue")
 
     // MARK: Initializers
 
@@ -114,6 +119,7 @@ public class DiscordClient: DiscordShardManagerDelegate, DiscordUserActor, Disco
     ) {
         self.token = token
         self.shardManager = DiscordShardManager(delegate: self)
+        self.voiceManager = DiscordVoiceManager(delegate: self)
         self.delegate = delegate
 
         for config in configuration {
@@ -124,6 +130,8 @@ public class DiscordClient: DiscordShardManagerDelegate, DiscordUserActor, Disco
                 self.rateLimiter = limiter
             case let .shardingInfo(shardingInfo):
                 self.shardingInfo = shardingInfo
+            case let .voiceConfiguration(config):
+                self.voiceManager.engineConfiguration = config
             case let .intents(intents):
                 self.intents = intents
             case .discardPresences:
@@ -174,6 +182,10 @@ public class DiscordClient: DiscordShardManagerDelegate, DiscordUserActor, Disco
         connected = false
 
         shardManager.disconnect()
+
+        for (_, engine) in voiceManager.get(voiceManager.voiceEngines) {
+            engine.disconnect()
+        }
     }
 
     ///
@@ -243,6 +255,7 @@ public class DiscordClient: DiscordShardManagerDelegate, DiscordUserActor, Disco
         case .threadDelete(let e): handleThreadDelete(with: e)
         case .voiceStateUpdate(let e): handleVoiceStateUpdate(with: e)
         case .interactionCreate(let e): handleInteractionCreate(with: e)
+        case .voiceServerUpdate(let e): handleVoiceServerUpdate(with: e)
         case .ready(let e): handleReady(with: e)
         default: delegate?.client(self, didNotHandleDispatchEvent: event)
         }
@@ -258,6 +271,39 @@ public class DiscordClient: DiscordShardManagerDelegate, DiscordUserActor, Disco
         return guilds
             .values
             .first { ($0.channels?[channelId] ?? $0.threads?[channelId]) != nil }
+    }
+
+    ///
+    /// Joins a voice channel. A `voiceEngine.ready` event will be fired when the client has joined the channel.
+    ///
+    /// - parameter channelId: The snowflake of the voice channel you would like to join
+    ///
+    open func joinVoiceChannel(_ channelId: ChannelID) {
+        guard let guild = guildForChannel(channelId), let channel = guild.channels[channelId] as? DiscordGuildVoiceChannel else {
+
+            return
+        }
+
+        logger.info("Joining voice channel: \(channel)")
+
+        shardManager.sendPayload(DiscordGatewayPayload(code: .gateway(.voiceStatusUpdate),
+                                                       payload: .object(["guild_id": String(describing: guild.id),
+                                                                         "channel_id": String(describing: channel.id),
+                                                                         "self_mute": false,
+                                                                         "self_deaf": false
+                                                                        ])
+        ), onShard: guild.shardNumber(assuming: shardingInfo.totalShards))
+    }
+
+    ///
+    /// Leaves the voice channel that is associated with the guild specified.
+    ///
+    /// - parameter onGuild: The snowflake of the guild that you want to leave.
+    ///
+    open func leaveVoiceChannel(onGuild guildId: GuildID) {
+        logger.info("Leaving voice channel on guild: \(guildId)")
+
+        voiceManager.leaveVoiceChannel(onGuild: guildId)
     }
 
     ///
@@ -287,6 +333,10 @@ public class DiscordClient: DiscordShardManagerDelegate, DiscordUserActor, Disco
         shardManager.sendPayload(.presenceUpdate(presence), onShard: 0)
     }
 
+    private func startVoiceConnection(_ guildId: GuildID) {
+        voiceManager.startVoiceConnection(guildId)
+    }
+
     // MARK: DiscordShardManagerDelegate conformance.
 
     public func shardManager(_ manager: DiscordShardManager, didConnect connected: Bool) {
@@ -314,6 +364,80 @@ public class DiscordClient: DiscordShardManagerDelegate, DiscordUserActor, Disco
     public func shardManager(_ manager: DiscordShardManager, shouldHandleEvent event: DiscordDispatchEvent) {
         handleQueue.async {
             self.handleDispatch(event: event)
+        }
+    }
+
+    ///
+    /// Called when an engine disconnects.
+    ///
+    /// - parameter manager: The manager.
+    /// - parameter engine: The engine that disconnected.
+    ///
+    open func voiceManager(_ manager: DiscordVoiceManager, didDisconnectEngine engine: DiscordVoiceEngine) {
+        handleQueue.async {
+            guard let shardNum = self.guilds[engine.guildId]?.shardNumber(assuming: self.shardingInfo.totalShards) else { return }
+
+            let payload = DiscordGatewayPayloadData.object(["guild_id": String(describing: engine.guildId),
+                                                            "channel_id": EncodableNull(),
+                                                            "self_mute": false,
+                                                            "self_deaf": false])
+
+            self.shardManager.sendPayload(DiscordGatewayPayload(code: .gateway(.voiceStatusUpdate), payload: payload),
+                                          onShard: shardNum)
+        }
+    }
+
+    ///
+    /// Called when a voice engine receives opus voice data.
+    ///
+    /// - parameter manager: The manager.
+    /// - parameter didReceiveVoiceData: The data received.
+    /// - parameter fromEngine: The engine that received the data.
+    ///
+    open func voiceManager(_ manager: DiscordVoiceManager, didReceiveOpusVoiceData data: DiscordOpusVoiceData,
+                           fromEngine engine: DiscordVoiceEngine) {
+        voiceQueue.async {
+            self.delegate?.client(self, didReceiveOpusVoiceData: data, fromEngine: engine)
+        }
+    }
+
+    ///
+    /// Called when a voice engine receives raw voice data.
+    ///
+    /// - parameter manager: The manager.
+    /// - parameter didReceiveVoiceData: The data received.
+    /// - parameter fromEngine: The engine that received the data.
+    ///
+    open func voiceManager(_ manager: DiscordVoiceManager, didReceiveRawVoiceData data: DiscordRawVoiceData,
+                           fromEngine engine: DiscordVoiceEngine) {
+        voiceQueue.async {
+            self.delegate?.client(self, didReceiveRawVoiceData: data, fromEngine: engine)
+        }
+    }
+
+    ///
+    /// Called when a voice engine needs a data source.
+    ///
+    /// **Not called on the handleQueue**
+    ///
+    /// - parameter manager: The manager that is requesting an encoder.
+    /// - parameter needsDataSourceForEngine: The engine that needs an encoder
+    /// - returns: An encoder.
+    ///
+    open func voiceManager(_ manager: DiscordVoiceManager,
+                           needsDataSourceForEngine engine: DiscordVoiceEngine) throws -> DiscordVoiceDataSource? {
+        return try delegate?.client(self, needsDataSourceForEngine: engine)
+    }
+
+    ///
+    /// Called when a voice engine is ready.
+    ///
+    /// - parameter manager: The manager.
+    /// - parameter engine: The engine that's ready.
+    ///
+    open func voiceManager(_ manager: DiscordVoiceManager, engineIsReady engine: DiscordVoiceEngine) {
+        handleQueue.async {
+            self.delegate?.client(self, isReadyToSendVoiceWithEngine: engine)
         }
     }
 
@@ -835,5 +959,60 @@ public class DiscordClient: DiscordShardManagerDelegate, DiscordUserActor, Disco
         // TODO: Use private_channels?
 
         delegate?.client(self, didReceiveReady: event)
+    }
+
+    ///
+    /// Handles voice server updates from Discord. You shouldn't need to call this method directly.
+    ///
+    /// Override to provide additional customization around this event.
+    ///
+    /// - parameter with: The data from the event
+    ///
+    open func handleVoiceServerUpdate(with data: [String: Any]) {
+        logger.info("Handling voice server update")
+        logger.debug("(verbose) Voice server update: \(data)")
+
+        let info = DiscordVoiceServerInformation(voiceServerInformationObject: data)
+
+        voiceManager.voiceServerInformations[info.guildId] = info
+
+        self.startVoiceConnection(info.guildId)
+    }
+
+    ///
+    /// Handles voice state updates from Discord. You shouldn't need to call this method directly.
+    ///
+    /// Override to provide additional customization around this event.
+    ///
+    /// Calls the `didReceiveVoiceStateUpdate` delegate method.
+    ///
+    /// - parameter with: The data from the event
+    ///
+    open func handleVoiceStateUpdate(with data: [String: Any]) {
+        logger.info("Handling voice state update")
+
+        guard let guildId = Snowflake(data["guild_id"] as? String) else { return }
+
+        let state = DiscordVoiceState(voiceStateObject: data, guildId: guildId)
+
+        logger.debug("(verbose) Voice state: \(state)")
+
+        if state.channelId == 0 {
+            guilds[guildId]?.voiceStates[state.userId] = nil
+        } else {
+            guilds[guildId]?.voiceStates[state.userId] = state
+        }
+
+        if state.userId == user?.id {
+            if state.channelId == 0 {
+                voiceManager.protected { self.voiceManager.voiceStates[state.guildId] = nil }
+            } else {
+                voiceManager.protected { self.voiceManager.voiceStates[state.guildId] = state }
+
+                startVoiceConnection(state.guildId)
+            }
+        }
+
+        delegate?.client(self, didReceiveVoiceStateUpdate: state)
     }
 }

--- a/Sources/Discord/DiscordClientDelegate.swift
+++ b/Sources/Discord/DiscordClientDelegate.swift
@@ -252,6 +252,38 @@ public protocol DiscordClientDelegate : AnyObject {
     func client(_ client: DiscordClient, didReceiveVoiceStateUpdate voiceState: DiscordVoiceState)
 
     ///
+    /// Called when the client is ready to start sending voice data.
+    ///
+    /// - parameter client: The client that is calling.
+    /// - parameter isReadyToSendVoiceWithEngine: The encoder that will be used.
+    ///
+    func client(_ client: DiscordClient, isReadyToSendVoiceWithEngine engine: DiscordVoiceEngine)
+
+    ///
+    /// Called when the client receives opus voice data.
+    ///
+    /// **Note** This is called from a queue that is dedicated to voice data, not the `handleQueue`.
+    ///
+    /// - parameter client: The client that is calling.
+    /// - parameter didReceiveOpusVoiceData: The voice data that was received.
+    /// - parameter fromEngine: The voice engine that received the data.
+    ///
+    func client(_ client: DiscordClient, didReceiveOpusVoiceData voiceData: DiscordOpusVoiceData,
+                fromEngine engine: DiscordVoiceEngine)
+
+    ///
+    /// Called when the client receives raw voice data.
+    ///
+    /// **Note** This is called from a queue that is dedicated to voice data, not the `handleQueue`.
+    ///
+    /// - parameter client: The client that is calling.
+    /// - parameter didReceiveRawVoiceData: The voice data that was received.
+    /// - parameter fromEngine: The voice engine that received the data.
+    ///
+    func client(_ client: DiscordClient, didReceiveRawVoiceData voiceData: DiscordRawVoiceData,
+                fromEngine engine: DiscordVoiceEngine)
+
+    ///
     /// Called when the client handles a guild member chunk.
     ///
     /// - parameter client: The client that is calling.
@@ -365,6 +397,9 @@ public extension DiscordClientDelegate {
     func client(_ client: DiscordClient, didReceiveVoiceStateUpdate voiceState: DiscordVoiceState) { }
 
     /// Default.
+    func client(_ client: DiscordClient, isReadyToSendVoiceWithEngine engine: DiscordVoiceEngine) { }
+
+    /// Default.
     func client(_ client: DiscordClient, didHandleGuildMemberChunk chunk: [DiscordGuildMember],
                 forGuild guild: DiscordGuild) { }
 
@@ -375,4 +410,20 @@ public extension DiscordClientDelegate {
     func client(_ client: DiscordClient, didUpdateEmojis emojis: [DiscordEmoji],
                 onGuild guild: DiscordGuild) { }
 
+    /// Default.
+    func client(_ client: DiscordClient, didReceiveOpusVoiceData voiceData: DiscordOpusVoiceData,
+                fromEngine engine: DiscordVoiceEngine) { }
+
+    /// Default.
+    func client(_ client: DiscordClient, didReceiveRawVoiceData voiceData: DiscordRawVoiceData,
+                fromEngine engine: DiscordVoiceEngine) { }
+
+    #if !os(iOS)
+    /// Default
+    func client(_ client: DiscordClient, needsDataSourceForEngine engine: DiscordVoiceEngine) throws -> DiscordVoiceDataSource {
+        return try DiscordBufferedVoiceDataSource(opusEncoder: DiscordOpusEncoder(bitrate: 128_000,
+                                                                                  sampleRate: 48_000,
+                                                                                  channels: 2))
+    }
+    #endif
 }

--- a/Sources/Discord/DiscordClientOption.swift
+++ b/Sources/Discord/DiscordClientOption.swift
@@ -56,6 +56,9 @@ public enum DiscordClientOption : CustomStringConvertible, Equatable {
     /// will create one internally and also shut it down on deinitialization.
     case eventLoopGroup(EventLoopGroup)
 
+    /// The settings for voice engines. See `DiscordVoiceEngineConfiguration` for defaults.
+    case voiceConfiguration(DiscordVoiceEngineConfiguration)
+
     // MARK: Properties
 
     /// - returns: A description of this option
@@ -70,6 +73,7 @@ public enum DiscordClientOption : CustomStringConvertible, Equatable {
         case .pruneUsers:           return "pruneUsers"
         case .intents:              return "intents"
         case .eventLoopGroup:       return "eventLoopGroup"
+        case .voiceConfiguration:   return "voiceConfiguration"
         }
     }
 

--- a/Sources/Discord/DiscordClientSpec.swift
+++ b/Sources/Discord/DiscordClientSpec.swift
@@ -20,7 +20,7 @@ import Foundation
 import Dispatch
 
 /// Protocol that abstracts a DiscordClient
-public protocol DiscordClientSpec: DiscordShardManagerDelegate, DiscordUserActor {
+public protocol DiscordClientSpec: DiscordVoiceManagerDelegate, DiscordShardManagerDelegate, DiscordUserActor {
 	// MARK: Properties
 
 	/// Whether or not this client is connected.
@@ -54,6 +54,20 @@ public protocol DiscordClientSpec: DiscordShardManagerDelegate, DiscordUserActor
 	/// Disconnects from Discord. A `disconnect` event is fired when the client has successfully disconnected.
 	///
 	func disconnect()
+
+	///
+	/// Joins a voice channel. A `voiceEngine.ready` event will be fired when the client has joined the channel.
+	///
+	/// - parameter channelId: The snowflake of the voice channel you would like to join
+	///
+	func joinVoiceChannel(_ channelId: ChannelID)
+
+	///
+	/// Leaves the currently connected voice channel.
+	///
+	/// - parameter onGuild: The snowflake of the guild whose voice channel you would like to leave.
+	///
+	func leaveVoiceChannel(onGuild guildId: GuildID)
 
 	///
 	/// Requests all users from Discord for the guild specified. Use this when you need to get all users on a large

--- a/Sources/Discord/Voice/DiscordOpusCoding.swift
+++ b/Sources/Discord/Voice/DiscordOpusCoding.swift
@@ -1,0 +1,205 @@
+// The MIT License (MIT)
+// Copyright (c) 2017 Erik Little
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without
+// limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+// Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+import COpus
+import Foundation
+
+/// Declares that a type has enough information to encode/decode Opus data.
+public protocol DiscordOpusCodeable {
+    // MARK: Properties
+
+    /// The number of channels.
+    var channels: Int { get }
+
+    /// The sampling rate.
+    var sampleRate: Int { get }
+
+    // MARK: Methods
+
+    ///
+    /// Returns the maximum number of bytes that a frame can contain given a
+    /// frame size in number of samples per channel.
+    ///
+    /// - parameter assumingSize: The size of the frame, in number of samples per channel.
+    /// - returns: The number of bytes in this frame.
+    ///
+    func maxFrameSize(assumingSize size: Int) -> Int
+}
+
+public extension DiscordOpusCodeable {
+    ///
+    /// Returns the maximum number of bytes that a frame can contain given a
+    /// frame size in number of samples per channel.
+    ///
+    /// - parameter assumingSize: The size of the frame, in number of samples per channel.
+    /// - returns: The number of bytes in this frame.
+    ///
+    func maxFrameSize(assumingSize size: Int) -> Int {
+        return size * channels * MemoryLayout<opus_int16>.size
+    }
+}
+
+///
+/// An Opus encoder.
+///
+/// Takes raw PCM 16-bit-lesample data and returns Opus encoded voice packets.
+///
+open class DiscordOpusEncoder : DiscordOpusCodeable {
+    // MARK: Properties
+
+    /// The bitrate for this encoder.
+    public let bitrate: Int
+
+    /// The number of channels.
+    public let channels: Int
+
+    /// The maximum size of a opus packet.
+    public var maxPacketSize: Int { return 4000 }
+
+    /// The sampling rate.
+    public let sampleRate: Int
+
+    private let encoderState: OpaquePointer
+
+    // MARK: Initializers
+
+    ///
+    /// Creates an Encoder that can take raw PCM data and create Opus packets.
+    ///
+    /// - parameter bitrate: The target bitrate for this encoder.
+    /// - parameter sampleRate: The sample rate for the encoder. Discord expects this to be 48k.
+    /// - parameter channels: The number of channels in the stream to encode, should always be 2.
+    ///
+    public init(bitrate: Int, sampleRate: Int = 48_000, channels: Int = 2, vbr: Bool = false) throws {
+        self.bitrate = bitrate
+        self.sampleRate = sampleRate
+        self.channels = channels
+
+        var err = 0 as Int32
+
+        encoderState = opus_encoder_create(Int32(sampleRate), Int32(channels), OPUS_APPLICATION_VOIP, &err)
+        let err2 = opus_encoder_set_bitrate(encoderState, Int32(bitrate))
+        let err3 = opus_encoder_set_vbr(encoderState, vbr ? 1 : 0)
+
+        guard err == 0, err2 == 0, err3 == 0 else {
+            destroyState()
+
+            throw DiscordVoiceError.creationFail
+        }
+    }
+
+    deinit {
+        destroyState()
+    }
+
+    // MARK: Methods
+
+    private func destroyState() {
+        opus_encoder_destroy(encoderState)
+    }
+
+    ///
+    /// Encodes a single frame of raw PCM 16-bit-le/sample LE data into Opus format.
+    ///
+    /// - parameter audio: A pointer to the audio data. Use `maxFrameSize(assumingSize:)` to find the length.
+    /// - parameter frameSize: The size of the frame in samples per channel.
+    /// - returns: An opus encoded packet.
+    ///
+    open func encode(_ audio: UnsafePointer<opus_int16>, frameSize: Int) throws -> [UInt8] {
+        let output = UnsafeMutablePointer<UInt8>.allocate(capacity: maxPacketSize)
+        let lenPacket = opus_encode(encoderState, audio, Int32(frameSize), output, opus_int32(maxPacketSize))
+
+        defer { output.deallocate() }
+
+        guard lenPacket > 0 else { throw DiscordVoiceError.encodeFail }
+
+        return Array(UnsafeBufferPointer(start: output, count: Int(lenPacket)))
+    }
+}
+
+///
+/// An Opus decoder.
+///
+/// Takes Opus packets and returns raw PCM 16-bit-lesample data.
+///
+open class DiscordOpusDecoder : DiscordOpusCodeable {
+    // MARK: Properties
+
+    /// The number of channels.
+    public let channels: Int
+
+    /// The sampling rate.
+    public let sampleRate: Int
+
+    private let decoderState: OpaquePointer
+
+    // MARK: Initializers
+
+    ///
+    /// Creates a Decoder that takes Opus encoded data and outputs raw PCM 16-bit-lesample data.
+    ///
+    /// - parameter sampleRate: The sample rate for the decoder. Discord expects this to be 48k.
+    /// - parameter channels: The number of channels in the stream to decode, should always be 2.
+    /// - parameter gain: The gain for this decoder.
+    ///
+    public init(sampleRate: Int, channels: Int, gain: Int = 0) throws {
+        self.sampleRate = sampleRate
+        self.channels = channels
+
+        var err = 0 as Int32
+
+        decoderState = opus_decoder_create(Int32(sampleRate), Int32(channels), &err)
+        let err2 = opus_decoder_set_gain(decoderState, Int32(gain))
+
+        guard err == 0, err2 == 0 else {
+            destroyState()
+
+            throw DiscordVoiceError.creationFail
+        }
+    }
+
+    deinit {
+        destroyState()
+    }
+
+    // MARK: Methods
+
+    private func destroyState() {
+        opus_decoder_destroy(decoderState)
+    }
+
+    ///
+    /// Decodes Opus data into raw PCM 16-bit-lesample data.
+    ///
+    /// - parameter audio: A pointer to the audio data.
+    /// - parameter packetSize: The number of bytes in this packet.
+    /// - parameter frameSize: The size of the frame in samples per channel.
+    /// - returns: An opus encoded packet.
+    ///
+    open func decode(_ audio: UnsafePointer<UInt8>?, packetSize: Int, frameSize: Int) throws -> [opus_int16] {
+        let maxSize = maxFrameSize(assumingSize: frameSize)
+        let output = UnsafeMutablePointer<opus_int16>.allocate(capacity: maxSize)
+        let decodedSize = Int(opus_decode(decoderState, audio, Int32(packetSize), output, Int32(frameSize), 0))
+        let totalSize = decodedSize * channels
+
+        defer { output.deallocate() }
+
+        guard decodedSize > 0, totalSize <= maxSize else { throw DiscordVoiceError.decodeFail }
+
+        return Array(UnsafeBufferPointer(start: output, count: totalSize))
+    }
+}

--- a/Sources/Discord/Voice/DiscordVoiceDataSource.swift
+++ b/Sources/Discord/Voice/DiscordVoiceDataSource.swift
@@ -1,0 +1,460 @@
+// The MIT License (MIT)
+// Copyright (c) 2017 Erik Little
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without
+// limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+// Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+import COpus
+import Dispatch
+import Foundation
+import Logging
+
+fileprivate let logger = Logger(label: "DiscordVoiceDataSource")
+
+/// Specifies that a type will be a data source for a VoiceEngine.
+public protocol DiscordVoiceDataSource : AnyObject {
+    // MARK: Properties
+
+    /// The size of a frame in samples per channel. Needed to calculate the maximum size of a frame.
+    var frameSize: Int { get }
+
+    // MARK: Methods
+
+    ///
+    /// Called when the engine needs voice data. If there is no more data left,
+    /// a `DiscordVoiceDataSourceStatus.done` error should be thrown.
+    ///
+    /// - parameter engine: The voice engine that needs data.
+    /// - returns: An array of Opus encoded bytes.
+    ///
+    func engineNeedsData(_ engine: DiscordVoiceEngine) throws -> [UInt8]
+
+    ///
+    /// Call when you want data collection to stop.
+    ///
+    func finishUpAndClose()
+
+    /// Signals that the source should start producing data for consumption.
+    func startReading()
+}
+
+/// Used to report the status of a data request if data could not be returned.
+public enum DiscordVoiceDataSourceStatus : Error {
+    /// Thrown when there is no more data left to be consumed.
+    case done
+
+    /// Special case used by the engine to tell itself that it should call for a new voice data source.
+    case silenceDone(DiscordVoiceDataSource?)
+
+    /// Thrown when an error occurs during a request.
+    case error
+
+    /// Thrown when there is no data to be read.
+    case noData
+}
+
+///
+/// DiscordBufferedVoiceDataSource is generic data source around a pipe. The only condition is that it expects raw
+/// PCM 16-bit-le out of the pipe.
+///
+/// It buffers ~5 minutes worth of voice data
+///
+/// Usage:
+///
+/// ```swift
+/// func client(_ client: DiscordClient, needsDataSourceForEngine engine: DiscordVoiceEngine) throws -> DiscordVoiceDataSource {
+///     return DiscordBufferedVoiceDataSource(opusEncoder: try DiscordOpusEncoder(bitrate: 128_000))
+///     // Somewhere down the line we setup some middleware which will use this source.
+/// }
+/// ```
+///
+open class DiscordBufferedVoiceDataSource : DiscordVoiceDataSource {
+    // MARK: Properties
+
+    /// The max number of voice packets to buffer.
+    /// Roughly equal to `(nPackets * 20ms) / 1000 = seconds to buffer`.
+    public let bufferSize: Int
+
+    /// The number of packets that must be in the buffer before we start reading more into the buffer.
+    public let drainThreshold: Int
+
+    /// The queue for this encoder.
+    public let encoderQueue = DispatchQueue(label: "discordVoiceEncoder.encoderQueue")
+
+    /// The Opus encoder.
+    public let opusEncoder: DiscordOpusEncoder
+
+    /// The size of a frame in samples per channel. Needed to calculate the maximum size of a frame.
+    public var frameSize = 960
+
+    #if !os(iOS)
+    /// A middleware process that spits out raw PCM for the encoder.
+    public var middleware: DiscordEncoderMiddleware?
+    #endif
+
+    /// The DispatchIO source for this buffered source.
+    public var source: DispatchIO!
+
+    /// What the encoder reads from, and what a consumer writes to to have things encoded into Opus
+    public private(set) var pipe: Pipe
+
+    /// A file handle that can be used to write to the encoder.
+    /// - returns: A file handle that can be written to.
+    public var writeToHandler: FileHandle {
+        // iOS doesn't have FFmpeg middleware. So it's safe to return what normally is the write to FFmpeg.
+        return pipe.fileHandleForWriting
+    }
+
+    private var closed = false
+    private var done = false
+    private var drain = false
+    private var readBuffer = [[UInt8]]()
+
+    // MARK: Initializers
+
+    ///
+    /// Sets up a raw encoder. This contains no FFmpeg middleware, so you must write raw PCM data to the encoder.
+    ///
+    /// - parameter opusEncoder: The Opus encoder to use.
+    /// - parameter bufferSize: The max number of voice packets to buffer.
+    /// - parameter drainThreshold: The number of packets that must be in the buffer before we start reading more
+    /// into the buffer.
+    ///
+    public init(opusEncoder: DiscordOpusEncoder, bufferSize: Int = 15_000, drainThreshold: Int = 13_500) {
+        self.bufferSize = bufferSize
+        self.drainThreshold = drainThreshold
+        self.pipe = Pipe()
+        self.opusEncoder = opusEncoder
+        createDispatchIO()
+    }
+
+    deinit {
+        logger.debug("deinit")
+
+        guard !closed else { return }
+
+        closeEncoder()
+    }
+
+    // MARK: Methods
+
+    /// Abrubtly halts encoding and kills the encoder
+    open func closeEncoder() {
+        defer { closed = true }
+
+        // Cancel any reading we were doing
+        pipe.fileHandleForReading.closeFile()
+        pipe.fileHandleForWriting.closeFile()
+
+        source.close(flags: .stop)
+    }
+
+    ///
+    /// Called when it is time to setup a `DispatchIO` for reading.
+    ///
+    /// Override to attach a custom file descriptor. By default it uses an internal pipe.
+    ///
+    open func createDispatchIO() {
+        self.source = DispatchIO(type: .stream, fileDescriptor: pipe.fileHandleForReading.fileDescriptor,
+                                 queue: encoderQueue, cleanupHandler: {code in
+            logger.debug("Source spent: \(code)")
+        })
+    }
+
+    ///
+    /// Called when the engine needs voice data. If there is no more data left,
+    /// a `DiscordVoiceEngineDataSourceStatus.done` error should be thrown.
+    ///
+    /// - parameter engine: The voice engine that needs data.
+    /// - returns: An array of Opus encoded bytes.
+    ///
+    open func engineNeedsData(_ engine: DiscordVoiceEngine) throws -> [UInt8] {
+        var data: [UInt8]!
+        var done: Bool!
+
+        encoderQueue.sync {
+            done = self.done
+
+            logger.trace("Buffer state: count: \(self.readBuffer.count) drain: \(self.drain)")
+
+            if self.drain && self.readBuffer.count <= self.drainThreshold {
+                // The swamp has been drained, start reading again
+                logger.debug("Buffer drained, scheduling read")
+
+                self.drain = false
+                self.startReading()
+            }
+
+            guard self.readBuffer.count != 0 else { return }
+
+            data = self.readBuffer.removeFirst()
+        }
+
+        guard data != nil else {
+            if done {
+                throw DiscordVoiceDataSourceStatus.done
+            } else {
+                throw DiscordVoiceDataSourceStatus.noData
+            }
+        }
+
+        return data
+    }
+
+    /// Call only when you know you've finished writing data, but ffmpeg is still encoding, or has data we haven't read
+    /// This should cause ffmpeg to get an EOF on input, which will cause it to close once its output buffer is empty
+    open func finishUpAndClose() {
+        guard !closed else { return }
+
+        logger.debug("Closing pipe for writing")
+
+        writeToHandler.closeFile()
+
+        // DispatchIO on Linux doesn't seem to get EOF on pipe closes correctly
+        #if os(Linux)
+        source.close(flags: .stop)
+        #endif
+    }
+
+    ///
+    /// Starts listening to the writePipe.
+    ///
+    open func startReading() {
+        guard !closed else { return }
+
+        _read()
+    }
+
+    private func _read() {
+        let maxFrameSize = opusEncoder.maxFrameSize(assumingSize: frameSize)
+
+        source.read(offset: 0, length: maxFrameSize, queue: encoderQueue) {[weak self] done, data, code in
+            guard let this = self else { return }
+
+            guard let data = data, data.count > 0 else {
+                logger.debug("No data, reader probably closed")
+
+                this.done = true
+
+                if done && code == 0 {
+                    // EOF reached
+                    logger.debug("Reader done")
+                } else {
+                    logger.debug("Something is weird \(done) \(code)")
+                }
+
+                return
+            }
+
+            logger.debug("Read \(data.count) bytes")
+
+            do {
+                try data.withUnsafeBytes {(bytes: UnsafePointer<opus_int16>) in
+                    this.readBuffer.append(try this.opusEncoder.encode(bytes, frameSize: this.frameSize))
+                }
+
+                guard this.readBuffer.count < this.bufferSize else {
+                    // Buffer is full; wait till it's drained
+                    // Whatever is in charge of taking from the buffer should queue up more reading
+                    logger.debug("Buffer full, not reading again")
+                    this.drain = true
+
+                    return
+                }
+
+                this._read()
+            } catch {
+                logger.error("Error encoding bytes")
+            }
+        }
+    }
+}
+
+///
+/// A subclass of `DiscordBufferedVoiceDataSource` that buffers a raw audio file.
+///
+/// Usage:
+///
+/// ```swift
+/// func client(_ client: DiscordClient, needsDataSourceForEngine engine: DiscordVoiceEngine) throws -> DiscordVoiceDataSource {
+///     return try DiscordVoiceFileDataSource(opusEncoder: try DiscordOpusEncoder(bitrate: 128_000),
+///                                           file: URL(string: "file://output.raw")!)
+/// }
+/// ```
+///
+open class DiscordVoiceFileDataSource : DiscordBufferedVoiceDataSource {
+    // MARK: Properties
+
+    /// A FileHandle for reading the wrapped file.
+    public let wrappedFile: FileHandle
+
+    // MARK: Initializers
+
+    ///
+    /// Sets up a buffered source around a voice file.
+    ///
+    /// - parameter opusEncoder: The Opus encoder to use.
+    /// - parameter file: A file to buffer around.
+    /// - parameter bufferSize: The max number of voice packets to buffer.
+    /// - parameter drainThreshold: The number of packets that must be in the buffer before we start reading more
+    /// into the buffer.
+    ///
+    public init(opusEncoder: DiscordOpusEncoder,
+                file: URL,
+                bufferSize: Int = 15_000,
+                drainThreshold: Int = 13_500) throws {
+        self.wrappedFile = try FileHandle(forReadingFrom: file)
+
+        super.init(opusEncoder: opusEncoder, bufferSize: bufferSize, drainThreshold: drainThreshold)
+    }
+
+    deinit {
+        logger.debug("deinit")
+    }
+
+    // MARK: Methods
+
+    ///
+    /// Called when it is time to setup a `DispatchIO` for reading.
+    ///
+    /// Override to attach a custom file descriptor. By default it uses `wrappedFile`.
+    ///
+    open override func createDispatchIO() {
+        self.source = DispatchIO(type: .stream, fileDescriptor: wrappedFile.fileDescriptor,
+                                 queue: encoderQueue, cleanupHandler: {code in
+            logger.debug("Source spent: \(code)")
+        })
+    }
+}
+
+///
+/// A voice source that returns Opus silence.
+/// Only sends 5 packets of silence and is then spent.
+///
+public final class DiscordSilenceVoiceDataSource : DiscordVoiceDataSource {
+    /// The size of the frame.
+    public let frameSize = 960
+
+    /// The source from a previous engine that is being carried over.
+    public let previousSource: DiscordVoiceDataSource?
+
+    private var i = 0
+
+    ///
+    /// Creates a new silence data source. If `previousSource` is sent then when the silence data
+    /// is used it the engine will attempt to use `previousSource` rather than asking for a new source.
+    ///
+    public init(previousSource: DiscordVoiceDataSource?) {
+        self.previousSource = previousSource
+    }
+
+    ///
+    /// Returns silence packets.
+    ///
+    /// - parameter engine: The engine requesting data.
+    /// - returns: Opus encoded silence.
+    ///
+    public func engineNeedsData(_ engine: DiscordVoiceEngine) throws -> [UInt8] {
+        guard i < 5 else { throw DiscordVoiceDataSourceStatus.silenceDone(previousSource) }
+
+        i += 1
+
+        return [0xF8, 0xFF, 0xFE]
+    }
+
+    ///
+    /// Unimplemented
+    ///
+    public func finishUpAndClose() { }
+
+    ///
+    /// Unimplemented
+    ///
+    public func startReading() { }
+}
+
+#if !os(iOS)
+///
+/// A wrapper class for a process that spits out audio data that can be fed into an FFmpeg process that is then sent
+/// to the engine.
+///
+///
+public class DiscordEncoderMiddleware {
+    // MARK: Properties
+
+    /// The FFmpeg process.
+    public let ffmpeg: Process
+
+    /// The middleware process.
+    public let middleware: Process
+
+    /// The pipe used to connect FFmpeg to the middleware.
+    public let pipe: Pipe
+
+    // MARK: Initializers
+
+    ///
+    /// An intializer that sets up a middleware ffmpeg process that encodes some audio data.
+    ///
+    public init(source: DiscordBufferedVoiceDataSource, middleware: Process, terminationHandler: (() -> ())?) {
+        self.middleware = middleware
+        ffmpeg = Process()
+        pipe = Pipe()
+
+        middleware.standardOutput = pipe
+        
+        let ffmpegPath = "/usr/local/bin/ffmpeg"
+        let ffmpegURL = URL(fileURLWithPath: ffmpegPath)
+        
+        pathSetter: do {
+            #if os(macOS)
+            guard #available(macOS 10.13, *) else {
+                ffmpeg.launchPath = ffmpegPath
+                break pathSetter
+            }
+            #endif
+            ffmpeg.executableURL = ffmpegURL
+        }
+
+        ffmpeg.standardInput = pipe
+        ffmpeg.standardOutput = source.writeToHandler
+        ffmpeg.arguments = ["-hide_banner", "-loglevel", "quiet", "-i", "pipe:0", "-f", "s16le", "-map", "0:a",
+                            "-ar", "48000", "-ac", "2", "-b:a", "128000", "-acodec", "pcm_s16le", "pipe:1"]
+
+        middleware.terminationHandler = {_ in
+            terminationHandler?()
+        }
+
+        ffmpeg.terminationHandler = {[weak source] _ in
+            source?.finishUpAndClose()
+        }
+    }
+    
+    ///
+    /// Starts the middleware.
+    ///
+    public func start() throws {
+        #if os(macOS)
+        guard #available(macOS 10.13, *) else {
+            ffmpeg.launch()
+            middleware.launch()
+            return
+        }
+        #endif
+
+        try ffmpeg.run()
+        try middleware.run()
+    }
+}
+#endif

--- a/Sources/Discord/Voice/DiscordVoiceDecoder.swift
+++ b/Sources/Discord/Voice/DiscordVoiceDecoder.swift
@@ -1,0 +1,137 @@
+// The MIT License (MIT)
+// Copyright (c) 2017 Erik Little
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without
+// limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+// Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+import COpus
+import Foundation
+import Logging
+
+fileprivate let logger = Logger(label: "DiscordVoiceDecoder")
+
+/// Class that decodes Opus voice data into raw PCM data for a VoiceEngine. It can decode multiple streams. Decoding is
+/// not thread safe, and it is up to the caller to decode safely.
+open class DiscordVoiceSessionDecoder {
+    private var decoders = [Int: DiscordOpusDecoder]()
+    private var sequences = [Int: Int]()
+    private var timestamps = [Int: Int]()
+
+    // MARK: Methods
+
+    ///
+    /// Decodes an opus encoded packet into raw PCM.
+    ///
+    /// - parameter packet: The Opus encoded packet.
+    /// - returns: A `DiscordRawVoiceData`.
+    ///
+    open func decode(_ packet: DiscordOpusVoiceData) throws -> DiscordRawVoiceData {
+        let decoder: DiscordOpusDecoder
+
+        if let previous = decoders[packet.ssrc] {
+            logger.debug("Reusing decoder for ssrc: \(packet.ssrc), seqNum: \(packet.seqNum), timestamp: \(packet.timestamp)")
+            decoder = previous
+        } else {
+            logger.debug("New decoder for ssrc: \(packet.ssrc), seqNum: \(packet.seqNum), timestamp: \(packet.timestamp)")
+            decoder = try DiscordOpusDecoder(sampleRate: 48_000, channels: 2)
+            decoders[packet.ssrc] = decoder
+        }
+
+        guard let previousSeqNum = sequences[packet.ssrc], let previousTimestamp = timestamps[packet.ssrc] else {
+            sequences[packet.ssrc] = packet.seqNum
+            timestamps[packet.ssrc] = packet.timestamp
+
+            throw DiscordVoiceError.initialPacket
+        }
+
+        guard packet.seqNum == previousSeqNum &+ 1 else {
+            if packet.seqNum < previousSeqNum {
+                // Don't handle old packets
+                throw DiscordVoiceError.decodeFail
+            }
+
+            sequences[packet.ssrc] = packet.seqNum
+            timestamps[packet.ssrc] = packet.timestamp
+
+            logger.debug("Out of order packet")
+            logger.debug("Looks to have a sequence difference of \(packet.seqNum - previousSeqNum)")
+
+            for _ in 0..<packet.seqNum-previousSeqNum {
+                // TODO Don't hardcode the frameSize
+                _ = try decoder.decode(nil, packetSize: 0, frameSize: 960)
+            }
+
+            throw DiscordVoiceError.decodeFail
+        }
+
+        let decoded = try packet.voiceData.withUnsafeBytes {bytes -> [opus_int16] in
+            let pointer = bytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+
+            return try decoder.decode(pointer,
+                                      packetSize: packet.voiceData.count,
+                                      frameSize: packet.timestamp - previousTimestamp)
+        }
+
+        sequences[packet.ssrc] = packet.seqNum
+        timestamps[packet.ssrc] = packet.timestamp
+
+        return DiscordRawVoiceData(opusPacket: packet, rawVoice: decoded)
+    }
+}
+
+/// A struct that contains a Discord voice packet with raw data.
+public struct DiscordRawVoiceData {
+    /// The sequence number of this packet.
+    public let seqNum: Int
+
+    /// The source of this packet.
+    public let ssrc: Int
+
+    /// The timestamp of this packet.
+    public let timestamp: Int
+
+    /// The raw voice data.
+    public let voiceData: [Int16]
+
+    fileprivate init(opusPacket: DiscordOpusVoiceData, rawVoice: [Int16]) {
+        seqNum = opusPacket.seqNum
+        ssrc = opusPacket.ssrc
+        timestamp = opusPacket.timestamp
+        voiceData = rawVoice
+    }
+}
+
+/// A struct that contains a Discord voice packet with Opus encoded data.
+public struct DiscordOpusVoiceData {
+    /// The sequence number of this packet.
+    public let seqNum: Int
+
+    /// The source of this packet.
+    public let ssrc: Int
+
+    /// The timestamp of this packet.
+    public let timestamp: Int
+
+    /// The opus voice data.
+    public let voiceData: [UInt8]
+
+    init(voicePacket: [UInt8]) {
+        let rtpHeader = Array(voicePacket.prefix(12)).map(Int.init(_:))
+
+        voiceData = Array(voicePacket.dropFirst(12))
+        seqNum = rtpHeader[2] << 8 | rtpHeader[3]
+        timestamp = rtpHeader[4] << 24 | rtpHeader[5] << 16 | rtpHeader[6] << 8 | rtpHeader[7]
+        ssrc = rtpHeader[8] << 24 | rtpHeader[9] << 16 | rtpHeader[10] << 8 | rtpHeader[11]
+    }
+}

--- a/Sources/Discord/Voice/DiscordVoiceEngine.swift
+++ b/Sources/Discord/Voice/DiscordVoiceEngine.swift
@@ -1,0 +1,713 @@
+// The MIT License (MIT)
+// Copyright (c) 2016 Erik Little
+// Copyright (c) 2021 fwcd
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without
+// limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+// Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+import Foundation
+import Dispatch
+import Logging
+import WebSocketKit
+import Socket
+import CSodium
+
+fileprivate let logger = Logger(label: "DiscordVoiceEngine")
+
+///
+/// A subclass of `DiscordEngine` that provides functionality for voice communication.
+///
+/// Discord uses encrypted OPUS encoded voice packets. The engine is responsible for encyrptingdecrypting voice
+/// packets that are sent and received.
+///
+public final class DiscordVoiceEngine: DiscordVoiceEngineSpec {
+    enum EngineError : Error {
+        case decryptionError
+        case encryptionError
+        case ipExtraction
+        case unknown
+    }
+
+    // MARK: Properties
+
+    private static let padding = [UInt8](repeating: 0x00, count: 12)
+
+    /// The configuration for this engine.
+    public let config: DiscordVoiceEngineConfiguration
+
+    /// The heartbeat queue.
+    public let heartbeatQueue = DispatchQueue(label: "discordVoiceEngine.heartbeatQueue")
+
+    /// The parse queue.
+    public let parseQueue = DispatchQueue(label: "discordVoiceEngine.parseQueue")
+
+    /// The run loop for this shard.
+    public let runloop: EventLoop
+
+    /// The voice url
+    public var connectURL: String {
+        return "wss://\(voiceServerInformation.endpoint.components(separatedBy: ":")[0])?v=4"
+    }
+
+    /// The connect UUID of this WebSocketable.
+    public var connectUUID = UUID()
+
+    /// The type of `DiscordEngine` this is. Used to correctly fire engine events.
+    public var description: String {
+        return "voiceEngine"
+    }
+
+    /// The id of the guild this voice engine is for.
+    public var guildId: GuildID {
+        return voiceState.guildId
+    }
+
+    /// Creates the handshake object that Discord expects.
+    public var handshakeObject: [String: Any] {
+        return [
+            "session_id": voiceState.sessionId,
+            "server_id": String(describing: voiceState.guildId),
+            "user_id": String(describing: voiceState.userId),
+            "token": voiceServerInformation.token
+        ]
+    }
+
+    /// Not used in voice gateways
+    public var resumeObject: [String: Any] {
+        return [:]
+    }
+
+    /// The underlying websocket.
+    public var websocket: WebSocket?
+
+    /// The voice engine's delegate.
+    public private(set) weak var voiceDelegate: DiscordVoiceEngineDelegate?
+
+    /// The heartbeat interval for this engine.
+    public private(set) var heartbeatInterval = -1
+
+    /// The data source for this engine. This source is responsible for giving us Opus data that is ready to send.
+    public private(set) var source: DiscordVoiceDataSource?
+
+    /// The modes that are available for communication. Only xsalsa20_poly1305 is supported currently
+    public private(set) var modes = [String]()
+
+    /// The secret key used for encryption
+    public private(set) var secret: [UInt8]!
+
+    /// Our SSRC
+    public private(set) var ssrc: UInt32 = 0
+
+    /// The UDP socket that is used to send/receive voice data
+    public private(set) var udpSocket: Socket?
+
+    // Server UDP ip
+    public private(set) var udpIp = ""
+
+    /// Server UDP port
+    public private(set) var udpPort = -1
+
+    /// Information about the voice server we are connected to
+    public private(set) var voiceServerInformation: DiscordVoiceServerInformation!
+
+    /// The voice state for this engine.
+    public private(set) var voiceState: DiscordVoiceState!
+
+    private let decoderSession = DiscordVoiceSessionDecoder()
+    private let sendTimer: DispatchSourceTimer
+    private let udpQueueWrite = DispatchQueue(label: "discordVoiceEngine.udpQueueWrite")
+    private let udpQueueRead = DispatchQueue(label: "discordVoiceEngine.udpQueueRead")
+
+    private var currentUnixTime: Int {
+        return Int(Date().timeIntervalSince1970 * 1000)
+    }
+
+    private var connected = false
+    private var closed = false
+
+    #if !os(Linux)
+    private var sequenceNum = UInt16(arc4random() >> 16)
+    private var timestamp = arc4random()
+    #else
+    private var sequenceNum = UInt16(random() >> 16)
+    private var timestamp = UInt32(random())
+    #endif
+
+    private var speaking = false
+
+    // MARK: Initializers
+
+    ///
+    /// Constructs a new VoiceEngine
+    ///
+    /// - parameter delegate: The client this engine should be associated with
+    /// - parameter voiceServerInformation: The voice server information
+    /// - parameter encoder: A DiscordVoiceEncoder that from a previous engine. Send if you are still encoding i.e
+    /// moved channels
+    /// - parameter secret: The secret from a previous engine.
+    ///
+    public init(delegate: DiscordVoiceEngineDelegate,
+                onLoop: EventLoop,
+                config: DiscordVoiceEngineConfiguration,
+                voiceServerInformation: DiscordVoiceServerInformation,
+                voiceState: DiscordVoiceState,
+                source: DiscordVoiceDataSource?,
+                secret: [UInt8]?) {
+        self.voiceDelegate = delegate
+        self.runloop = onLoop
+        self.config = config
+
+        _ = sodium_init()
+
+        signal(SIGPIPE, SIG_IGN)
+
+        self.voiceState = voiceState
+        self.voiceServerInformation = voiceServerInformation
+        self.source = source
+        self.secret = secret
+        self.sendTimer = DispatchSource.makeTimerSource(flags: .strict, queue: udpQueueWrite)
+
+        configureTimer()
+    }
+
+    deinit {
+        logger.debug("deinit")
+
+        closeOutEngine()
+    }
+
+    // MARK: Methods
+
+    private func closeOutEngine() {
+        guard !closed else { return }
+
+        udpSocket?.close()
+        closed = true
+        connected = false
+        sendTimer.cancel()
+    }
+
+    private func configureTimer() {
+        self.sendTimer.setEventHandler {[weak self] in
+            guard let this = self else { return }
+
+            this.getVoiceData()
+        }
+
+        self.sendTimer.schedule(wallDeadline: .now(), repeating: .milliseconds(20))
+
+        // TODO this is wasteful, figure out if there's a smart way to start and stop the timer.
+        // Maybe let the user decide?
+        sendTimer.resume()
+    }
+
+    private func createRTPHeader() -> [UInt8] {
+        let header = UnsafeMutableRawBufferPointer.allocate(byteCount: 12, alignment: MemoryLayout<Int>.alignment)
+
+        defer { header.deallocate() }
+
+        header.storeBytes(of: 0x80, as: UInt8.self)
+        header.storeBytes(of: 0x78, toByteOffset: 1, as: UInt8.self)
+        header.storeBytes(of: sequenceNum.bigEndian, toByteOffset: 2, as: UInt16.self)
+        header.storeBytes(of: timestamp.bigEndian, toByteOffset: 4, as: UInt32.self)
+        header.storeBytes(of: ssrc.bigEndian, toByteOffset: 8, as: UInt32.self)
+
+        return Array(header)
+    }
+
+    private func createVoicePacket(_ data: [UInt8]) throws -> [UInt8] {
+        let packetSize = Int(crypto_secretbox_MACBYTES) + data.count
+        let encrypted = UnsafeMutablePointer<UInt8>.allocate(capacity: packetSize)
+        let rtpHeader = createRTPHeader()
+        let nonce = rtpHeader + DiscordVoiceEngine.padding
+        let buf = data
+
+        defer { encrypted.deallocate() }
+
+        let success = crypto_secretbox_easy(encrypted, buf, UInt64(buf.count), nonce, secret)
+
+        guard success != -1 else { throw EngineError.encryptionError }
+
+        return rtpHeader + Array(UnsafeBufferPointer(start: encrypted, count: packetSize))
+    }
+
+    private func decryptVoiceData(_ data: Data) throws -> [UInt8] {
+        // TODO this isn't totally correct, there might be an extension after the rtp header
+        let rtpHeader = Array(data.prefix(12))
+        let voiceData = Array(data.dropFirst(12))
+        let audioSize = voiceData.count - Int(crypto_secretbox_MACBYTES)
+
+        guard audioSize > 0 else { throw EngineError.decryptionError }
+
+        let unencrypted = UnsafeMutablePointer<UInt8>.allocate(capacity: audioSize)
+        let nonce = rtpHeader + DiscordVoiceEngine.padding
+
+        defer { unencrypted.deallocate() }
+
+        let success = crypto_secretbox_open_easy(unencrypted, voiceData, UInt64(data.count - 12), nonce, secret)
+
+        guard success != -1 else { throw EngineError.decryptionError }
+
+        return rtpHeader + Array(UnsafeBufferPointer(start: unencrypted, count: audioSize))
+    }
+
+    ///
+    /// Disconnects the voice engine.
+    ///
+    public func disconnect() {
+        logger.info("Disconnecting VoiceEngine")
+
+        closeWebSockets()
+        closeOutEngine()
+
+        voiceDelegate?.voiceEngineDidDisconnect(self)
+    }
+
+    private func extractIPAndPort(from bytes: Data) throws -> (String, Int) {
+        logger.debug("Extracting ip and port from \(bytes)")
+
+        let ipData = bytes.dropLast(2)
+        let portBytes = Array(bytes.suffix(from: bytes.endIndex.advanced(by: -2)))
+        let port = (Int(portBytes[0]) | Int(portBytes[1])) << 8
+
+        guard let ipString = String(data: ipData, encoding: .utf8)?.replacingOccurrences(of: "\0", with: "") else {
+            throw EngineError.ipExtraction
+        }
+
+        return (ipString, port)
+    }
+
+    // https://discord.com/developers/docs/topics/voice-connections#ip-discovery
+    private func findIP() {
+        udpQueueWrite.async {
+            guard let udpSocket = self.udpSocket else { return }
+
+            let discoveryData = [UInt8](repeating: 0x00, count: 70)
+
+            do {
+                var data = Data()
+                try udpSocket.write(from: Data(discoveryData))
+
+                _ = try udpSocket.readDatagram(into: &data)
+                let (ip, port) = try self.extractIPAndPort(from: data)
+
+                self.selectProtocol(with: ip, on: port)
+            } catch {
+                self.error(message: "Something went wrong extracting the ip and port \(error)")
+                self.disconnect()
+            }
+        }
+    }
+
+    private func getNewDataSource() {
+        // Guard against trying to create multiple encoders at once
+        udpQueueWrite.async {
+            do {
+                self.source = try self.voiceDelegate?.voiceEngineNeedsDataSource(self)
+
+                self.readSource()
+
+                self.voiceDelegate?.voiceEngineReady(self)
+            } catch {
+                self.error(message: "Something went wrong getting a new data source \(error)")
+                self.disconnect()
+            }
+        }
+    }
+
+    private func getVoiceData() {
+        guard let source = source else { return }
+
+        do {
+            sendVoiceData(try source.engineNeedsData(self))
+        } catch DiscordVoiceDataSourceStatus.noData {
+            logger.trace("No data")
+
+            if speaking {
+                sendSpeaking(false)
+            }
+        } catch DiscordVoiceDataSourceStatus.done {
+            logger.debug("Voice source done, sending silence")
+
+            sendSilence(previousSource: nil)
+        } catch let DiscordVoiceDataSourceStatus.silenceDone(source) {
+            logger.debug("Voice silence done, requesting new source")
+
+            if speaking {
+                sendSpeaking(false)
+            }
+
+            if source == nil {
+                getNewDataSource()
+            } else {
+                // This silence had a source from a previous engine and we just finished sending the initial silence
+                // re-add the old source for playback
+                self.source = source
+            }
+        } catch {
+            logger.error("Error getting voice data: \(error)")
+        }
+    }
+
+    ///
+    /// Handles a close from the WebSocket.
+    ///
+    /// - parameter reason: The reason the socket closed.
+    ///
+    public func handleClose(reason: DiscordGatewayCloseReason) {
+        logger.info("Voice engine closed with reason \(reason)")
+
+        closeOutEngine()
+    }
+
+    /// Currently unused in VoiceEngines.
+    public func handleDispatch(_ payload: DiscordGatewayPayload) { }
+
+    ///
+    /// Handles the hello event.
+    ///
+    /// - parameter payload: The dispatch payload
+    ///
+    public func handleHello(_ payload: DiscordGatewayPayload) {
+        logger.debug("Handling hello \(payload)")
+
+        guard case let .object(helloPayload) = payload.payload,
+              let heartbeat = helloPayload["heartbeat_interval"] as? Int else {
+            logger.error("Error extracting heartbeat info \(payload)")
+
+            return
+        }
+
+        startHeartbeat(milliseconds: Int(Double(heartbeat) * 0.75))
+    }
+
+    ///
+    /// Handles a DiscordGatewayPayload. You shouldn't need to call this directly.
+    ///
+    /// Override this method if you need to customize payload handling.
+    ///
+    /// - parameter payload: The payload object
+    ///
+    public func handleGatewayPayload(_ payload: DiscordVoiceGatewayPayload) {
+        switch payload.code {
+        case .ready:
+            handleReady(with: payload.payload)
+        case .sessionDescription:
+            udpQueueWrite.sync {
+                self.handleVoiceSessionDescription(with: payload.payload)
+                self.sendSilence(previousSource: self.source)
+            }
+        case .speaking:
+            logger.debug("Got speaking \(payload)")
+        case .hello:
+            handleHello(payload)
+        case .heartbeatAck:
+            logger.debug("Got heartbeat ack")
+        case .resumed:
+            handleResumed(payload)
+        case .clientDisconnect:
+            // Should we tell someone about this?
+            logger.debug("Someone left voice channel \(payload)")
+        default:
+            logger.debug("Unhandled voice payload \(payload)")
+        }
+    }
+
+    private func handleReady(with payload: DiscordGatewayPayloadData) {
+        guard case let .object(voiceInformation) = payload,
+              let ssrc = voiceInformation["ssrc"] as? Int,
+              let udpPort = voiceInformation["port"] as? Int,
+              let modes = voiceInformation["modes"] as? [String], 
+              let ip = voiceInformation["ip"] as? String else {
+            disconnect()
+
+            return
+        }
+
+        self.udpPort = udpPort
+        self.modes = modes
+        self.ssrc = UInt32(ssrc)
+        self.udpIp = ip
+
+        startUDP()
+    }
+
+    ///
+    /// Handles the resumed event.
+    ///
+    /// - parameter payload: The payload for the event.
+    ///
+    public func handleResumed(_ payload: DiscordGatewayPayload) {
+        // TODO implement voice resume
+        logger.debug("Should handle resumed \(payload)")
+    }
+
+    private func handleVoiceSessionDescription(with payload: DiscordGatewayPayloadData) {
+        guard case let .object(voiceInformation) = payload,
+              let secret = voiceInformation["secret_key"] as? [Int] else {
+            disconnect()
+
+            return
+        }
+
+        self.secret = secret.map({ UInt8($0) })
+    }
+
+    ///
+    /// Parses a raw message from the WebSocket. This is the entry point for voice events.
+    /// You shouldn't call this directly.
+    ///
+    public func parseGatewayMessage(_ string: String) {
+        guard let decoded = DiscordGatewayPayload.payloadFromString(string, fromGateway: false) else {
+            logger.info("Got unknown payload \(string)")
+
+            return
+        }
+
+        handleGatewayPayload(decoded)
+    }
+
+    private func readSource() {
+        source?.startReading()
+    }
+
+    private func readSocket() {
+        // TODO refactor to be non-blocking
+        udpQueueRead.async {[weak self] in
+            guard let socket = self?.udpSocket, self?.connected ?? false else { return }
+
+            do {
+                var data = Data()
+
+                _ = try socket.readDatagram(into: &data)
+
+                logger.debug("Received data \(data)")
+
+                guard let this = self else { return }
+
+                let packet = DiscordOpusVoiceData(voicePacket: try this.decryptVoiceData(data))
+
+                if this.config.decodeVoice {
+                    this.voiceDelegate?.voiceEngine(this,
+                                                    didReceiveRawVoiceData: try this.decoderSession.decode(packet))
+                } else {
+                    this.voiceDelegate?.voiceEngine(this, didReceiveOpusVoiceData: packet)
+                }
+            } catch DiscordVoiceError.initialPacket {
+                logger.debug("Got initial packet")
+            } catch DiscordVoiceError.decodeFail {
+                logger.debug("Failed to decode a packet")
+            } catch EngineError.decryptionError {
+                self?.error(message: "Error decrypting voice packet")
+            } catch let err {
+                self?.error(message: "Error reading voice data from udp socket \(err)")
+                self?.disconnect()
+
+                return
+            }
+
+            self?.readSocket()
+        }
+    }
+
+    ///
+    /// Stops encoding and requests a new encoder. The `isReadyToSendVoiceWithEngine` delegate method is called when
+    /// the new encoder is ready.
+    ///
+    public func requestNewDataSource() {
+        getNewDataSource()
+    }
+
+    // Tells the voice websocket what our ip and port is, and what encryption mode we will use
+    // currently only xsalsa20_poly1305 is supported
+    // After this point we are good to go in sending encrypted voice packets
+    private func selectProtocol(with ip: String, on port: Int) {
+        logger.debug("Selecting UDP protocol with ip: \(ip) on port: \(port)")
+
+        let payloadData: [String: Any] = [
+            "protocol": "udp",
+            "data": [
+                "address": ip,
+                "port": port,
+                "mode": "xsalsa20_poly1305"
+            ]
+        ]
+
+        sendPayload(DiscordGatewayPayload(code: .voice(.selectProtocol), payload: .object(payloadData)))
+        connected = true
+
+        // No need to get ask for a source, we send silence before we get this step,
+        // which will cause an ask for a new source
+        readSource()
+
+        logger.debug("VoiceEngine is ready!")
+
+        guard config.captureVoice else { return }
+
+        readSocket()
+    }
+
+    ///
+    /// Sends a voice heartbeat to Discord. You shouldn't need to call this directly.
+    ///
+    public func sendHeartbeat() {
+        guard !closed else { return }
+
+        sendPayload(DiscordGatewayPayload(code: .voice(.heartbeat), payload: .integer(currentUnixTime)))
+
+        let time = DispatchTime.now() + .milliseconds(heartbeatInterval)
+
+        heartbeatQueue.asyncAfter(deadline: time) {[weak self] in self?.sendHeartbeat() }
+    }
+
+    /// Only call between new data source requests, assumes inside the udpWriteQueue.
+    private func sendSilence(previousSource: DiscordVoiceDataSource?) {
+        source = DiscordSilenceVoiceDataSource(previousSource: previousSource)
+    }
+
+    ///
+    /// Sends whether we are speaking or not.
+    ///
+    /// - parameter speaking: Our speaking status.
+    ///
+    private func sendSpeaking(_ speaking: Bool) {
+        self.speaking = speaking
+
+        let speakingObject: [String: Any] = [
+            "speaking": 1 << 1,
+            "delay": 0,
+            "ssrc": ssrc
+        ]
+
+        sendPayload(DiscordGatewayPayload(code: .voice(.speaking), payload: .object(speakingObject)))
+    }
+
+    ///
+    /// Sends Opus encoded voice data to Discord.
+    ///
+    /// **This should be called on the udpWriteQueue**.
+    ///
+    /// - parameter data: An Opus encoded packet.
+    ///
+    private func sendVoiceData(_ data: [UInt8]) {
+        guard let udpSocket = self.udpSocket, let frameSize = source?.frameSize, secret != nil else { return }
+
+        if !speaking {
+            sendSpeaking(true)
+        }
+
+        logger.trace("Should send voice data: \(data.count) bytes")
+
+        do {
+            try udpSocket.write(from: Data(createVoicePacket(data)))
+        } catch EngineError.encryptionError {
+            error(message: "Error encrypting packet")
+        } catch let err {
+            error(message: "Failed sending voice packet \(err)")
+            disconnect()
+
+            return
+        }
+
+        sequenceNum = sequenceNum &+ 1
+        timestamp = timestamp &+ UInt32(frameSize)
+    }
+
+    #if !os(iOS)
+    ///
+    /// Takes a process that outputs random audio data, and sends it to a hidden FFmpeg process that turns the data
+    /// into raw PCM.
+    ///
+    /// Example setting up youtube-dl to play music.
+    ///
+    /// ```swift
+    /// youtube = EncoderProcess()
+    /// youtube.launchPath = "usrlocalbinyoutube-dl"
+    /// youtube.arguments = ["-f", "bestaudio", "-q", "-o", "-", link]
+    ///
+    /// voiceEngine.setupMiddleware(youtube) {
+    ///     print("youtube died")
+    /// }
+    /// ```
+    ///
+    /// **Currently only works if using the default `DiscordBufferedVoiceDataSource`**
+    ///
+    /// - parameter middleware: The process that will output audio data.
+    /// - parameter terminationHandler: Called when the middleware is done. Does not mean that all encoding is done.
+    ///
+    public func setupMiddleware(_ middleware: Process, terminationHandler: (() -> ())?) {
+        logger.debug("Setting up middleware")
+
+        // TODO this is bad, fix the types here
+        guard let source = self.source as? DiscordBufferedVoiceDataSource else { return }
+
+        source.middleware = DiscordEncoderMiddleware(source: source,
+                                                     middleware: middleware,
+                                                     terminationHandler: terminationHandler)
+        do {
+            try source.middleware?.start()
+        } catch {
+            logger.error("Could not start middleware: \(error)")
+        }
+    }
+    #endif
+
+    ///
+    /// Starts the handshake with the Discord voice server. You shouldn't need to call this directly.
+    ///
+    public func startHandshake() {
+        guard voiceDelegate != nil else { return }
+
+        logger.info("Starting voice handshake")
+
+        sendPayload(DiscordGatewayPayload(code: .voice(.identify), payload: .object(handshakeObject)))
+    }
+
+    ///
+    /// Starts the engine's heartbeat. You should call this method when you know the interval that Discord expects.
+    ///
+    /// - parameter milliseconds: The heartbeat interval
+    ///
+    public func startHeartbeat(milliseconds: Int) {
+        heartbeatInterval = milliseconds
+
+        sendHeartbeat()
+    }
+
+    private func startUDP() {
+        guard udpPort != -1, !udpIp.isEmpty else { return }
+
+        logger.debug("Starting voice UDP connection")
+
+        do {
+            guard let sig = try Socket.Signature(
+                    protocolFamily: .inet,
+                    socketType: .datagram,
+                    proto: .udp,
+                    hostname: "\(udpIp)",
+                    port: Int32(udpPort)
+            ) else {
+                throw EngineError.unknown
+            }
+
+            udpSocket = try Socket.create(connectedUsing: sig)
+
+            // Begin async UDP setup
+            findIP()
+        } catch let err {
+            // TODO Handle voice error disconnect from voice
+            logger.error("UDP setup error \(err)")
+        }
+    }
+}

--- a/Sources/Discord/Voice/DiscordVoiceEngineSpec.swift
+++ b/Sources/Discord/Voice/DiscordVoiceEngineSpec.swift
@@ -1,0 +1,144 @@
+// The MIT License (MIT)
+// Copyright (c) 2016 Erik Little
+// Copyright (c) 2021 fwcd
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without
+// limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+// Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+import COpus
+import Foundation
+
+/// Declares that a type will be a voice engine.
+public protocol DiscordVoiceEngineSpec : DiscordWebSocketable, DiscordGatewayable, DiscordRunLoopable {
+    // MARK: Properties
+
+    /// The encoder for this engine. The encoder is responsible for turning raw audio data into OPUS encoded data.
+    var source: DiscordVoiceDataSource? { get }
+
+    /// The secret key used for encryption.
+    var secret: [UInt8]! { get }
+
+    // MARK: Methods
+
+    ///
+    /// Stops encoding and requests a new encoder. A `voiceEngine.ready` event will be fired when the encoder is ready.
+    ///
+    func requestNewDataSource()
+
+    #if !os(iOS)
+    ///
+    /// Takes a process that outputs random audio data, and sends it to a hidden FFmpeg process that turns the data
+    /// into raw PCM.
+    ///
+    /// Example setting up youtube-dl to play music.
+    ///
+    /// ```swift
+    /// youtube = EncoderProcess()
+    /// youtube.launchPath = "usrlocalbinyoutube-dl"
+    /// youtube.arguments = ["-f", "bestaudio", "-q", "-o", "-", link]
+    ///
+    /// voiceEngine.setupMiddleware(youtube) {
+    ///     print("youtube died")
+    /// }
+    /// ```
+    ///
+    /// - parameter middleware: The process that will output audio data.
+    /// - parameter terminationHandler: Called when the middleware is done. Does not mean that all encoding is done.
+    ///
+    func setupMiddleware(_ middleware: Process, terminationHandler: (() -> ())?)
+    #endif
+}
+
+/// Declares that a type will be a client for a voice engine.
+public protocol DiscordVoiceEngineDelegate : AnyObject {
+    // MARK: Methods
+
+    ///
+    /// Handles received opus voice data from a voice engine.
+    ///
+    /// - parameter data: The voice data that was received
+    ///
+    func voiceEngine(_ engine: DiscordVoiceEngine, didReceiveOpusVoiceData data: DiscordOpusVoiceData)
+
+    ///
+    /// Handles received raw voice data from a voice engine.
+    ///
+    /// - parameter data: The voice data that was received
+    ///
+    func voiceEngine(_ engine: DiscordVoiceEngine, didReceiveRawVoiceData data: DiscordRawVoiceData)
+
+    ///
+    /// Called when the voice engine disconnects.
+    ///
+    /// - parameter engine: The engine that disconnected.
+    ///
+    func voiceEngineDidDisconnect(_ engine: DiscordVoiceEngine)
+
+    ///
+    /// Called when the voice engine needs an encoder.
+    ///
+    /// - parameter engine: The engine that needs an encoder.
+    /// - returns: An encoder.
+    ///
+    func voiceEngineNeedsDataSource(_ engine: DiscordVoiceEngine) throws -> DiscordVoiceDataSource?
+
+    ///
+    /// Called when the voice engine is ready.
+    ///
+    /// - parameter engine: The engine that's ready.
+    ///
+    func voiceEngineReady(_ engine: DiscordVoiceEngine)
+}
+
+/// Represents an error that can occur during voice operations.
+public enum DiscordVoiceError : Error {
+    /// Thrown when a failure occurs creating an encoder.
+    case creationFail
+
+    /// Thrown when a failure occurs encoding.
+    case encodeFail
+
+    /// Thrown when a decode failure occurs.
+    case decodeFail
+
+    /// Thrown when the first packet is received.
+    case initialPacket
+}
+
+/// A struct that is used to configure the high-level functions of a VoiceEngine
+public struct DiscordVoiceEngineConfiguration {
+    /// Whether or not this engine should capture voice.
+    public var captureVoice: Bool
+
+    /// Whether or not this engine should try and decode incoming voice into raw PCM.
+    public var decodeVoice: Bool
+
+    ///
+    /// Default configuration:
+    ///     captureVoice = true
+    ///     decodeVoice = false
+    ///
+    public init() {
+        captureVoice = true
+        decodeVoice = false
+    }
+
+    ///
+    /// Creates a new configuration with the specified options.
+    ///
+    public init(captureVoice: Bool, decodeVoice: Bool) {
+        self.captureVoice = captureVoice
+        self.decodeVoice = decodeVoice
+    }
+}

--- a/Sources/Discord/Voice/DiscordVoiceManager.swift
+++ b/Sources/Discord/Voice/DiscordVoiceManager.swift
@@ -1,0 +1,235 @@
+// The MIT License (MIT)
+// Copyright (c) 2017 Erik Little
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without
+// limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+// Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+import Dispatch
+import Foundation
+import Logging
+
+fileprivate let logger = Logger(label: "DiscordVoiceManager")
+
+/// A delegate for a VoiceManager.
+public protocol DiscordVoiceManagerDelegate : AnyObject, DiscordTokenBearer, DiscordEventLoopGroupManager {
+    // MARK: Methods
+
+    ///
+    /// Called when an engine disconnects.
+    ///
+    /// - parameter manager: The manager.
+    /// - parameter engine: The engine that disconnected.
+    ///
+    func voiceManager(_ manager: DiscordVoiceManager, didDisconnectEngine engine: DiscordVoiceEngine)
+
+    ///
+    /// Called when a voice engine receives opus voice data.
+    ///
+    /// - parameter manager: The manager.
+    /// - parameter didReceiveOpusVoiceData: The data received.
+    /// - parameter fromEngine: The engine that received the data.
+    ///
+    func voiceManager(_ manager: DiscordVoiceManager, didReceiveOpusVoiceData data: DiscordOpusVoiceData,
+                      fromEngine engine: DiscordVoiceEngine)
+
+    ///
+    /// Called when a voice engine receives raw voice data.
+    ///
+    /// - parameter manager: The manager.
+    /// - parameter didReceiveRawVoiceData: The data received.
+    /// - parameter fromEngine: The engine that received the data.
+    ///
+    func voiceManager(_ manager: DiscordVoiceManager, didReceiveRawVoiceData data: DiscordRawVoiceData,
+                      fromEngine engine: DiscordVoiceEngine)
+
+    ///
+    /// Called when a voice engine is ready.
+    ///
+    /// - parameter manager: The manager.
+    /// - parameter engine: The engine that's ready.
+    ///
+    func voiceManager(_ manager: DiscordVoiceManager, engineIsReady engine: DiscordVoiceEngine)
+
+    ///
+    /// Called when a voice engine needs a data source.
+    ///
+    /// - parameter manager: The manager that is requesting an encoder.
+    /// - parameter engine: The engine that needs an encoder
+    /// - returns: A data source.
+    ///
+    func voiceManager(_ manager: DiscordVoiceManager,
+                      needsDataSourceForEngine engine: DiscordVoiceEngine) throws -> DiscordVoiceDataSource?
+}
+
+/// A manager for voice engines.
+open class DiscordVoiceManager : DiscordVoiceEngineDelegate, Lockable {
+    // MARK: Properties
+
+    /// The delegate for this manager.
+    public weak var delegate: DiscordVoiceManagerDelegate?
+
+    /// The configuration for engines.
+    public var engineConfiguration: DiscordVoiceEngineConfiguration
+
+    /// The token for the user.
+    public var token: DiscordToken {
+        return delegate!.token
+    }
+
+    /// The voice engines, indexed by guild id.
+    public private(set) var voiceEngines = DiscordIDDictionary<DiscordVoiceEngine>()
+
+    /// The voice states for this user, if they are in any voice channels.
+    public internal(set) var voiceStates = DiscordIDDictionary<DiscordVoiceState>()
+
+    let lock = DispatchSemaphore(value: 1)
+
+    var voiceServerInformations = DiscordIDDictionary<DiscordVoiceServerInformation>()
+
+    private var logType: String { return "DiscordVoiceManager" }
+
+    // MARK: Initializers
+
+    ///
+    /// Creates a new manager with the delegate set.
+    ///
+    public init(delegate: DiscordVoiceManagerDelegate,
+                engineConfiguration: DiscordVoiceEngineConfiguration = DiscordVoiceEngineConfiguration()) {
+        self.delegate = delegate
+        self.engineConfiguration = engineConfiguration
+    }
+
+    // MARK: Methods
+
+    ///
+    /// Leaves the voice channel that is associated with the guild specified.
+    ///
+    /// - parameter onGuild: The snowflake of the guild that you want to leave.
+    ///
+    open func leaveVoiceChannel(onGuild guildId: GuildID) {
+        guard let engine = get(voiceEngines[guildId]) else {
+            logger.error("Could not find a voice engine for guild \(guildId)")
+
+            return
+        }
+
+        protected {
+            voiceStates[guildId] = nil
+            voiceServerInformations[guildId] = nil
+        }
+
+        logger.debug("(verbose) Disconnecting voice engine for guild \(guildId)")
+
+        engine.disconnect()
+
+        // Make sure everything is cleaned out
+
+        logger.debug("(verbose) Rejoining voice channels after leave")
+
+        for (guildId, _) in voiceEngines {
+            startVoiceConnection(guildId)
+        }
+    }
+
+    ///
+    /// Tries to open a voice connection to the specified guild.
+    /// Only succeeds if we have both a voice state and the voice server info for this guild.
+    ///
+    /// - parameter guildId: The id of the guild to connect to.
+    ///
+    open func startVoiceConnection(_ guildId: GuildID) {
+        protected {
+            _startVoiceConnection(guildId)
+        }
+    }
+
+    /// Tries to create a voice engine for a guild, and connect.
+    /// **Not thread safe.**
+    private func _startVoiceConnection(_ guildId: GuildID) {
+        guard let delegate = delegate else { return }
+
+        // We need both to start the connection
+        guard let voiceState = voiceStates[guildId], let serverInfo = voiceServerInformations[guildId] else {
+            return
+        }
+
+        // Reuse a previous engine's encoder if possible
+        let previousEngine = voiceEngines[guildId]
+        voiceEngines[guildId] = DiscordVoiceEngine(
+                delegate: self,
+                onLoop: delegate.runloops.next(),
+                config: engineConfiguration,
+                voiceServerInformation: serverInfo,
+                voiceState: voiceState,
+                source: previousEngine?.source,
+                secret: previousEngine?.secret
+        )
+
+        logger.info("Connecting voice engine")
+
+        DispatchQueue.global().async {[weak engine = voiceEngines[guildId]!] in
+            engine?.connect()
+        }
+    }
+
+    ///
+    /// Called when the voice engine disconnects.
+    ///
+    /// - parameter engine: The engine that disconnected.
+    ///
+    open func voiceEngineDidDisconnect(_ engine: DiscordVoiceEngine) {
+        delegate?.voiceManager(self, didDisconnectEngine: engine)
+
+        protected { voiceEngines[engine.guildId] = nil }
+    }
+
+    ///
+    /// Handles opus voice data received from a VoiceEngine
+    ///
+    /// - parameter didReceiveOpusVoiceData: A `DiscordOpusVoiceData` instance containing opus encoded voice data.
+    ///
+    open func voiceEngine(_ engine: DiscordVoiceEngine, didReceiveOpusVoiceData data: DiscordOpusVoiceData) {
+        delegate?.voiceManager(self, didReceiveOpusVoiceData: data, fromEngine: engine)
+    }
+
+    ///
+    /// Handles raw voice data received from a VoiceEngine
+    ///
+    /// - parameter didReceiveRawVoiceData: A `DiscordRawVoiceData` instance containing raw voice data.
+    ///
+    open func voiceEngine(_ engine: DiscordVoiceEngine, didReceiveRawVoiceData data: DiscordRawVoiceData) {
+        delegate?.voiceManager(self, didReceiveRawVoiceData: data, fromEngine: engine)
+    }
+
+    ///
+    /// Called when the voice engine needs an encoder.
+    ///
+    /// - parameter engine: The engine that needs an encoder
+    /// - returns: An encoder.
+    ///
+    open func voiceEngineNeedsDataSource(_ engine: DiscordVoiceEngine) throws -> DiscordVoiceDataSource? {
+        return try delegate?.voiceManager(self, needsDataSourceForEngine: engine)
+    }
+
+    ///
+    /// Called when the voice engine is ready.
+    ///
+    /// - parameter engine: The engine that's ready.
+    ///
+    open func voiceEngineReady(_ engine: DiscordVoiceEngine) {
+        delegate?.voiceManager(self, engineIsReady: engine)
+    }
+
+
+}

--- a/Sources/Discord/Voice/DiscordVoiceServer.swift
+++ b/Sources/Discord/Voice/DiscordVoiceServer.swift
@@ -1,0 +1,36 @@
+// The MIT License (MIT)
+// Copyright (c) 2017 Erik Little
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without
+// limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+// Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+/// Represents the information sent in a VoiceServerUpdate.
+public struct DiscordVoiceServerInformation {
+    // MARK: Properties
+    
+    /// The voice endpoint.
+    public let endpoint: String
+
+    /// The guild id that is associated with this update.
+    public let guildId: GuildID
+
+    /// The token for the voice connection.
+    public let token: String
+
+    init(voiceServerInformationObject: [String: Any]) {
+        endpoint = voiceServerInformationObject.get("endpoint", or: "")
+        guildId = Snowflake(voiceServerInformationObject["guild_id"] as? String) ?? 0
+        token = voiceServerInformationObject.get("token", or: "")
+    }
+}


### PR DESCRIPTION
A highly experimental branch that reverts 17217cf3f021af8f248eaf5d8cae7fb847bd17c5 to re-add the voice support previously removed in #4. Note that this branch currently does not compile and will likely need a large overhaul, including:

- Refactoring `DiscordVoiceEngine` to use `Codable` value types for its gateway events, this implementation still uses the legacy JSON serialization
- Splitting out the voice support into a separate target/library so that pure text bots are not burdened with the Opus/Sodium dependencies
- Perhaps factoring out the Opus and Sodium wrappers into separate libraries
- Adding snippets/examples for writing a simple voice bot

See also:

- The voice connection docs: https://discord.com/developers/docs/topics/voice-connections